### PR TITLE
Add modules and subworkflows from taxprofiler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ null/
 *~
 .nf-test*
 .data/
+*.code-workspace

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ testing*
 *.pyc
 null/
 *~
+.nf-test*
+.data/

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 
 ## Introduction
 
-**nf-core/funcprofiler** is a bioinformatics pipeline that ...
+**nf-core/funcprofiler** is a bioinformatics pipeline that performs end-to-end functional profiling of metagenomes. It is designed to be a standalone tool or used along other metagenomics pipelines such as [nf-core/taxprofiler](https://nf-co.re/taxprofiler/latest/) and [nf-core/mag](https://nf-co.re/mag/latest/). It allows for parallel functional identification of reads against multiple databases, and using a suite of different tools.
 
 <!-- TODO nf-core:
    Complete this sentence with a 2-3 sentence summary of what types of data the pipeline ingests, a brief overview of the
@@ -28,9 +28,22 @@
    to nf-core here, in 15-20 seconds. For an example, see https://github.com/nf-core/rnaseq/blob/master/README.md#introduction
 -->
 
+## Pipeline summary
+
 <!-- TODO nf-core: Include a figure that guides the user through the major workflow steps. Many nf-core
      workflows use the "tube map" design for that. See https://nf-co.re/docs/guidelines/graphic_design/workflow_diagrams#examples for examples.   -->
-<!-- TODO nf-core: Fill in short bullet-pointed list of the default steps in the pipeline -->1. Read QC ([`FastQC`](https://www.bioinformatics.babraham.ac.uk/projects/fastqc/))2. Present QC for raw reads ([`MultiQC`](http://multiqc.info/))
+<!-- TODO nf-core: Fill in short bullet-pointed list of the default steps in the pipeline -->
+
+1. Read QC ([`FastQC`](https://www.bioinformatics.babraham.ac.uk/projects/fastqc/) or [`falco`](https://github.com/smithlabcode/falco) as an alternative option)
+2. Optional read pre-processing
+   - Adapter clipping and merging (short-read: [fastp](https://github.com/OpenGene/fastp); long-read: [porechop](https://github.com/rrwick/Porechop))
+   - Host-read removal (short-read: [BowTie2](http://bowtie-bio.sourceforge.net/bowtie2/); long-read: [Minimap2](https://github.com/lh3/minimap2))
+   - Run merging
+4. Performs functional classification and/or profiling using one or more of:
+   - [humann3](http://huttenhower.sph.harvard.edu/humann)
+   - [DIAMOND](https://github.com/bbuchfink/diamond)
+   - [Resistance Gene Identifier](https://card.mcmaster.ca/analyze/rgi)
+5. Concatenate QC and profile reports ([`MultiQC`](http://multiqc.info/))
 
 ## Usage
 
@@ -77,7 +90,7 @@ For more details about the output files and reports, please refer to the
 
 ## Credits
 
-nf-core/funcprofiler was originally written by Nick Waters.
+nf-core/funcprofiler was originally written by Nick Waters and Vini Salazar.
 
 We thank the following people for their extensive assistance in the development of this pipeline:
 

--- a/conf/test.config
+++ b/conf/test.config
@@ -14,21 +14,41 @@ process {
     resourceLimits = [
         cpus: 4,
         memory: '15.GB',
-        time: '1.h'
+        time: '6.h',
     ]
+    executor = 'local'
+}
+
+docker {
+    enabled = true
+}
+
+singularity {
+    enabled = false
+}
+
+apptainer {
+    enabled = false
+}
+
+conda {
+    enabled = false
 }
 
 params {
     config_profile_name                    = 'Test profile'
     config_profile_description             = 'Minimal test dataset to check pipeline function'
-    input                                  = 'https://raw.githubusercontent.com/nf-core/test-datasets/refs/heads/taxprofiler/samplesheet_shortreadsonly.csv'
-    databases                              = params.pipelines_testdata_base_path + 'database.csv'
-    databases                              = 'https://raw.githubusercontent.com/nickp60/test-datasets/refs/heads/funcprofiler/database.csv'
-    outdir                                 = "tmp"
-    run_fmhfunprofiler                     = true
-    run_humann_v3                          = true
-    run_humann_v4                          = true
+
+    // Input data
+    input                                  = params.pipelines_testdata_base_path + 'samplesheet.csv'
+    databases                              = params.pipelines_testdata_base_path + 'database_funcprofiler.csv'
+    perform_shortread_qc                   = true
+    perform_shortread_redundancyestimation = true
+    perform_longread_qc                    = true
+    shortread_qc_mergepairs                = true
+    perform_shortread_complexityfilter     = true
+    perform_shortread_hostremoval          = true
+    perform_longread_hostremoval           = true
     perform_runmerging                     = true
-    perform_shortread_qc                   = false
-    perform_longread_qc                    = false
+    hostremoval_reference                  = params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta'
 }

--- a/modules.json
+++ b/modules.json
@@ -5,12 +5,42 @@
         "https://github.com/nf-core/modules.git": {
             "modules": {
                 "nf-core": {
+                    "adapterremoval": {
+                        "branch": "master",
+                        "git_sha": "4dd9d8439a429c7ee566e0e2347f76ddeef27e66",
+                        "installed_by": ["modules"]
+                    },
+                    "bowtie2/align": {
+                        "branch": "master",
+                        "git_sha": "ab146e7909edbf6dcc6459de57eef29dceb61d42",
+                        "installed_by": ["modules"]
+                    },
+                    "bowtie2/build": {
+                        "branch": "master",
+                        "git_sha": "447f7bc0fa41dfc2400c8cad4c0291880dc060cf",
+                        "installed_by": ["modules"]
+                    },
                     "cat/fastq": {
                         "branch": "master",
                         "git_sha": "41dfa3f7c0ffabb96a6a813fe321c6d1cc5b6e46",
                         "installed_by": ["modules"]
                     },
+                    "falco": {
+                        "branch": "master",
+                        "git_sha": "41dfa3f7c0ffabb96a6a813fe321c6d1cc5b6e46",
+                        "installed_by": ["modules"]
+                    },
+                    "fastp": {
+                        "branch": "master",
+                        "git_sha": "a331ecfd1aa48b2b2298aab23bb4516c800e410b",
+                        "installed_by": ["modules"]
+                    },
                     "fastqc": {
+                        "branch": "master",
+                        "git_sha": "41dfa3f7c0ffabb96a6a813fe321c6d1cc5b6e46",
+                        "installed_by": ["modules"]
+                    },
+                    "filtlong": {
                         "branch": "master",
                         "git_sha": "41dfa3f7c0ffabb96a6a813fe321c6d1cc5b6e46",
                         "installed_by": ["modules"]
@@ -23,6 +53,21 @@
                     "multiqc": {
                         "branch": "master",
                         "git_sha": "41dfa3f7c0ffabb96a6a813fe321c6d1cc5b6e46",
+                        "installed_by": ["modules"]
+                    },
+                    "nanoq": {
+                        "branch": "master",
+                        "git_sha": "4dd9d8439a429c7ee566e0e2347f76ddeef27e66",
+                        "installed_by": ["modules"]
+                    },
+                    "porechop/abi": {
+                        "branch": "master",
+                        "git_sha": "10d3ce839d4c87bbff4da434e155a3c8a112ea05",
+                        "installed_by": ["modules"]
+                    },
+                    "porechop/porechop": {
+                        "branch": "master",
+                        "git_sha": "e753770db613ce014b3c4bc94f6cba443427b726",
                         "installed_by": ["modules"]
                     },
                     "untar": {

--- a/modules/nf-core/adapterremoval/environment.yml
+++ b/modules/nf-core/adapterremoval/environment.yml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/environment-schema.json
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  - bioconda::adapterremoval=2.3.2

--- a/modules/nf-core/adapterremoval/main.nf
+++ b/modules/nf-core/adapterremoval/main.nf
@@ -1,0 +1,119 @@
+process ADAPTERREMOVAL {
+    tag "$meta.id"
+    label 'process_medium'
+
+    conda "${moduleDir}/environment.yml"
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/adapterremoval:2.3.2--hb7ba0dd_0' :
+        'biocontainers/adapterremoval:2.3.2--hb7ba0dd_0' }"
+
+    input:
+    tuple val(meta), path(reads)
+    path(adapterlist)
+
+    output:
+    tuple val(meta), path("${prefix}.truncated.fastq.gz")          , emit: singles_truncated  , optional: true
+    tuple val(meta), path("${prefix}.discarded.fastq.gz")          , emit: discarded          , optional: true
+    tuple val(meta), path("${prefix}.pair{1,2}.truncated.fastq.gz"), emit: paired_truncated   , optional: true
+    tuple val(meta), path("${prefix}.collapsed.fastq.gz")          , emit: collapsed          , optional: true
+    tuple val(meta), path("${prefix}.collapsed.truncated.fastq.gz"), emit: collapsed_truncated, optional: true
+    tuple val(meta), path("${prefix}.paired.fastq.gz")             , emit: paired_interleaved , optional: true
+    tuple val(meta), path('*.settings')                            , emit: settings
+    path "versions.yml"                                            , emit: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args = task.ext.args   ?: ''
+    prefix   = task.ext.prefix ?: "${meta.id}"
+    def list = adapterlist ? "--adapter-list ${adapterlist}" : ""
+
+    if (meta.single_end) {
+        """
+        AdapterRemoval  \\
+            --file1 ${reads} \\
+            ${args} \\
+            ${list} \\
+            --basename ${prefix} \\
+            --threads ${task.cpus} \\
+            --seed 42 \\
+            --gzip
+
+        ensure_fastq() {
+            if [ -f "\${1}" ]; then
+                mv "\${1}" "\${1::-3}.fastq.gz"
+            fi
+
+        }
+
+        ensure_fastq '${prefix}.truncated.gz'
+        ensure_fastq '${prefix}.discarded.gz'
+
+        cat <<-END_VERSIONS > versions.yml
+        "${task.process}":
+            adapterremoval: \$(AdapterRemoval --version 2>&1 | sed -e "s/AdapterRemoval ver. //g")
+        END_VERSIONS
+        """
+    } else {
+        """
+        AdapterRemoval  \\
+            --file1 ${reads[0]} \\
+            --file2 ${reads[1]} \\
+            ${args} \\
+            ${list} \\
+            --basename ${prefix} \\
+            --threads ${task.cpus} \\
+            --seed 42 \\
+            --gzip
+
+        ensure_fastq() {
+            if [ -f "\${1}" ]; then
+                mv "\${1}" "\${1::-3}.fastq.gz"
+            fi
+
+        }
+
+        ensure_fastq '${prefix}.truncated.gz'
+        ensure_fastq '${prefix}.discarded.gz'
+        ensure_fastq '${prefix}.pair1.truncated.gz'
+        ensure_fastq '${prefix}.pair2.truncated.gz'
+        ensure_fastq '${prefix}.collapsed.gz'
+        ensure_fastq '${prefix}.collapsed.truncated.gz'
+        ensure_fastq '${prefix}.paired.gz'
+
+        cat <<-END_VERSIONS > versions.yml
+        "${task.process}":
+            adapterremoval: \$(AdapterRemoval --version 2>&1 | sed -e "s/AdapterRemoval ver. //g")
+        END_VERSIONS
+        """
+    }
+
+    stub:
+    def args = task.ext.args   ?: ''
+    prefix   = task.ext.prefix ?: "${meta.id}"
+
+    collapse_cmd = args.contains('--collapse')
+
+    """
+    touch '${prefix}.settings'
+    echo | gzip > '${prefix}.truncated.fastq.gz'
+    echo | gzip > '${prefix}.discarded.fastq.gz'
+
+    if [ "${meta.single_end}" = false ]; then
+        echo | gzip > '${prefix}.pair1.truncated.fastq.gz'
+        echo | gzip > '${prefix}.pair2.truncated.fastq.gz'
+        echo | gzip > '${prefix}.paired.fastq.gz'
+
+        if [ "${collapse_cmd}" = true ]; then
+            echo | gzip > '${prefix}.collapsed.truncated.fastq.gz'
+            echo | gzip > '${prefix}.collapsed.fastq.gz'
+        fi
+    fi
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        adapterremoval: \$(AdapterRemoval --version 2>&1 | sed -e "s/AdapterRemoval ver. //g")
+    END_VERSIONS
+    """
+}

--- a/modules/nf-core/adapterremoval/meta.yml
+++ b/modules/nf-core/adapterremoval/meta.yml
@@ -1,0 +1,137 @@
+name: adapterremoval
+description: Trim sequencing adapters and collapse overlapping reads
+keywords:
+  - trimming
+  - adapters
+  - merging
+  - fastq
+tools:
+  - adapterremoval:
+      description: The AdapterRemoval v2 tool for merging and clipping reads.
+      homepage: https://github.com/MikkelSchubert/adapterremoval
+      documentation: https://adapterremoval.readthedocs.io
+      licence: ["GPL v3"]
+      identifier: biotools:adapterremoval
+input:
+  - - meta:
+        type: map
+        description: |
+          Groovy Map containing sample information
+          e.g. [ id:'test', single_end:false ]
+    - reads:
+        type: file
+        description: |
+          List of input FastQ files of size 1 and 2 for single-end and paired-end data,
+          respectively.
+        pattern: "*.{fq,fastq,fq.gz,fastq.gz}"
+        ontologies:
+          - edam: "http://edamontology.org/format_1930" # FASTQ
+  - adapterlist:
+      type: file
+      description: Optional text file containing list of adapters to look for for removal
+        with one adapter per line. Otherwise will look for default adapters (see AdapterRemoval
+        man page), or can be modified to remove user-specified adapters via ext.args.
+      ontologies:
+        - edam: "http://edamontology.org/format_2330" # Textual format
+output:
+  singles_truncated:
+    - - meta:
+          type: map
+          description: Groovy Map containing sample information
+      - ${prefix}.truncated.fastq.gz:
+          type: file
+          description: |
+            Adapter trimmed FastQ files of either single-end reads, or singleton
+            'orphaned' reads from merging of paired-end data (i.e., one of the pair
+            was lost due to filtering thresholds).
+          pattern: "*.truncated.fastq.gz"
+          ontologies:
+            - edam: "http://edamontology.org/format_1930" # FASTQ
+            - edam: http://edamontology.org/format_3989 # GZIP format
+  discarded:
+    - - meta:
+          type: map
+          description: Groovy Map containing sample information
+      - ${prefix}.discarded.fastq.gz:
+          type: file
+          description: |
+            Adapter trimmed FastQ files of reads that did not pass filtering
+            thresholds.
+          pattern: "*.discarded.fastq.gz"
+          ontologies:
+            - edam: "http://edamontology.org/format_1930" # FASTQ
+            - edam: http://edamontology.org/format_3989 # GZIP format
+  paired_truncated:
+    - - meta:
+          type: map
+          description: Groovy Map containing sample information
+      - ${prefix}.pair{1,2}.truncated.fastq.gz:
+          type: file
+          description: |
+            Adapter trimmed R{1,2} FastQ files of paired-end reads that did not merge
+            with their respective R{1,2} pair due to long templates. The respective pair
+            is stored in 'pair{1,2}_truncated'.
+          pattern: "*.pair{1,2}.truncated.fastq.gz"
+          ontologies:
+            - edam: "http://edamontology.org/format_1930" # FASTQ
+  collapsed:
+    - - meta:
+          type: map
+          description: Groovy Map containing sample information
+      - ${prefix}.collapsed.fastq.gz:
+          type: file
+          description: |
+            Collapsed FastQ of paired-end reads that successfully merged with their
+            respective R1 pair but were not trimmed.
+          pattern: "*.collapsed.fastq.gz"
+          ontologies:
+            - edam: "http://edamontology.org/format_1930" # FASTQ
+            - edam: http://edamontology.org/format_3989 # GZIP format
+  collapsed_truncated:
+    - - meta:
+          type: map
+          description: Groovy Map containing sample information
+      - ${prefix}.collapsed.truncated.fastq.gz:
+          type: file
+          description: |
+            Collapsed FastQ of paired-end reads that successfully merged with their
+            respective R1 pair and were trimmed of adapter due to sufficient overlap.
+          pattern: "*.collapsed.truncated.fastq.gz"
+          ontologies:
+            - edam: "http://edamontology.org/format_1930" # FASTQ
+            - edam: http://edamontology.org/format_3989 # GZIP format
+  paired_interleaved:
+    - - meta:
+          type: map
+          description: Groovy Map containing sample information
+      - ${prefix}.paired.fastq.gz:
+          type: file
+          description: |
+            Write paired-end reads to a single file, interleaving mate 1 and mate 2 reads
+          pattern: "*.paired.fastq.gz"
+          ontologies:
+            - edam: "http://edamontology.org/format_1930" # FASTQ
+            - edam: http://edamontology.org/format_3989 # GZIP format
+  settings:
+    - - meta:
+          type: map
+          description: Groovy Map containing sample information
+      - "*.settings":
+          type: file
+          description: AdapterRemoval log file
+          pattern: "*.settings"
+          ontologies:
+            - edam: "http://edamontology.org/format_2330" # Textual format
+  versions:
+    - versions.yml:
+        type: file
+        description: File containing software versions
+        pattern: "versions.yml"
+        ontologies:
+          - edam: "http://edamontology.org/format_3750" # YAML
+authors:
+  - "@maxibor"
+  - "@jfy133"
+maintainers:
+  - "@maxibor"
+  - "@jfy133"

--- a/modules/nf-core/adapterremoval/tests/main.nf.test
+++ b/modules/nf-core/adapterremoval/tests/main.nf.test
@@ -1,0 +1,228 @@
+nextflow_process {
+
+    name "Test Process ADAPTERREMOVAL"
+    script "../main.nf"
+    config "./nextflow.config"
+    process "ADAPTERREMOVAL"
+
+    tag "modules"
+    tag "modules_nfcore"
+    tag "adapterremoval"
+
+    test("single-end - sarscov2 - [fastq]") {
+        when {
+            params {
+                adapterremoval_args = ""
+            }
+            process {
+                """
+                input[0] = [
+                            [ id:'test', single_end:true ],
+                            file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true)
+                ]
+                input[1] = []
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(
+                    process.out.singles_truncated,
+                    process.out.settings,
+                    process.out.versions
+                ).match() },
+            )
+        }
+    }
+
+    test("paired-end - sarscov2 - [fastq]") {
+
+        when {
+            params {
+                adapterremoval_args = ""
+            }
+            process {
+                """
+                input[0] = [
+                            [ id:'test', single_end:false ],
+                            [
+                                file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true),
+                                file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_2.fastq.gz', checkIfExists: true)
+                            ]
+                ]
+                input[1] = []
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(
+                    process.out.paired_truncated,
+                    process.out.settings,
+                    process.out.versions
+                ).match() }
+            )
+        }
+    }
+
+    test("paired-end collapse - sarscov2 - [fastq]") {
+        when {
+            params {
+                adapterremoval_args = "--collapse"
+            }
+            process {
+                """
+                input[0] = [
+                            [ id:'test', single_end:false ],
+                            [
+                                file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true),
+                                file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_2.fastq.gz', checkIfExists: true)
+                            ]
+                ]
+                input[1] = []
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(
+                    process.out.paired_truncated,
+                    process.out.collapsed,
+                    file(process.out.collapsed_truncated[0][1]).name, // Check for present but is empty
+                    process.out.settings,
+                    process.out.versions
+                ).match() }
+            )
+        }
+
+    }
+
+    test("paired-end adapterlist - sarscov2 - [fastq]") {
+        when {
+            params {
+                adapterremoval_args = ""
+            }
+            process {
+                """
+                input[0] = [
+                            [ id:'test', single_end:false ],
+                            [
+                                file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true),
+                                file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_2.fastq.gz', checkIfExists: true)
+                            ]
+                ]
+                input[1] = file(params.modules_testdata_base_path + '/delete_me/adapterremoval/adapterremoval_adapterlist.txt', checkIfExists: true)
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(
+                    process.out.paired_truncated,
+                    process.out.settings,
+                    process.out.versions
+                ).match() }
+            )
+        }
+    }
+
+    test("paired-end collapse adapterlist - sarscov2 - [fastq] -- stub") {
+        options "-stub"
+        when {
+            params {
+                adapterremoval_args = "--collapse"
+            }
+            process {
+                """
+                input[0] = [
+                            [ id:'test', single_end:false ],
+                            [
+                                file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true),
+                                file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_2.fastq.gz', checkIfExists: true)
+                            ]
+                ]
+                input[1] = file(params.modules_testdata_base_path + '/delete_me/adapterremoval/adapterremoval_adapterlist.txt', checkIfExists: true)
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(
+                    process.out,
+                    path(process.out.versions[0]).yaml
+                ).match() }
+            )
+        }
+    }
+
+    test("single-end - sarscov2 - [fastq] -- stub") {
+        options "-stub"
+        when {
+            params {
+                adapterremoval_args = ""
+            }
+            process {
+                """
+                input[0] = [
+                            [ id:'test', single_end:true ],
+                            file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true)
+                ]
+                input[1] = []
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(
+                    process.out,
+                    path(process.out.versions[0]).yaml
+                ).match() }
+            )
+        }
+    }
+
+    test("paired-end - sarscov2 - [fastq] -- stub") {
+        options "-stub"
+        when {
+            params {
+                adapterremoval_args = ""
+            }
+            process {
+                """
+                input[0] = [
+                            [ id:'test', single_end:false ],
+                            [
+                                file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true),
+                                file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_2.fastq.gz', checkIfExists: true)
+                            ]
+                ]
+                input[1] = []
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(
+                    process.out,
+                    path(process.out.versions[0]).yaml
+                ).match() }
+            )
+        }
+
+    }
+
+}

--- a/modules/nf-core/adapterremoval/tests/main.nf.test.snap
+++ b/modules/nf-core/adapterremoval/tests/main.nf.test.snap
@@ -1,0 +1,525 @@
+{
+    "paired-end collapse adapterlist - sarscov2 - [fastq] -- stub": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.truncated.fastq.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                    ]
+                ],
+                "1": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.discarded.fastq.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                    ]
+                ],
+                "2": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        [
+                            "test.pair1.truncated.fastq.gz:md5,68b329da9893e34099c7d8ad5cb9c940",
+                            "test.pair2.truncated.fastq.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                        ]
+                    ]
+                ],
+                "3": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.collapsed.fastq.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                    ]
+                ],
+                "4": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.collapsed.truncated.fastq.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                    ]
+                ],
+                "5": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.paired.fastq.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                    ]
+                ],
+                "6": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.settings:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "7": [
+                    "versions.yml:md5,00bcc9f0b864b96eeee21bc11773ee67"
+                ],
+                "collapsed": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.collapsed.fastq.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                    ]
+                ],
+                "collapsed_truncated": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.collapsed.truncated.fastq.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                    ]
+                ],
+                "discarded": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.discarded.fastq.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                    ]
+                ],
+                "paired_interleaved": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.paired.fastq.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                    ]
+                ],
+                "paired_truncated": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        [
+                            "test.pair1.truncated.fastq.gz:md5,68b329da9893e34099c7d8ad5cb9c940",
+                            "test.pair2.truncated.fastq.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                        ]
+                    ]
+                ],
+                "settings": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.settings:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "singles_truncated": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.truncated.fastq.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,00bcc9f0b864b96eeee21bc11773ee67"
+                ]
+            },
+            {
+                "ADAPTERREMOVAL": {
+                    "adapterremoval": "2.3.2"
+                }
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "25.04.2"
+        },
+        "timestamp": "2025-06-01T17:50:28.27707234"
+    },
+    "single-end - sarscov2 - [fastq] -- stub": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": true
+                        },
+                        "test.truncated.fastq.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                    ]
+                ],
+                "1": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": true
+                        },
+                        "test.discarded.fastq.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                    ]
+                ],
+                "2": [
+
+                ],
+                "3": [
+
+                ],
+                "4": [
+
+                ],
+                "5": [
+
+                ],
+                "6": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": true
+                        },
+                        "test.settings:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "7": [
+                    "versions.yml:md5,00bcc9f0b864b96eeee21bc11773ee67"
+                ],
+                "collapsed": [
+
+                ],
+                "collapsed_truncated": [
+
+                ],
+                "discarded": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": true
+                        },
+                        "test.discarded.fastq.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                    ]
+                ],
+                "paired_interleaved": [
+
+                ],
+                "paired_truncated": [
+
+                ],
+                "settings": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": true
+                        },
+                        "test.settings:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "singles_truncated": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": true
+                        },
+                        "test.truncated.fastq.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,00bcc9f0b864b96eeee21bc11773ee67"
+                ]
+            },
+            {
+                "ADAPTERREMOVAL": {
+                    "adapterremoval": "2.3.2"
+                }
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "24.10.5"
+        },
+        "timestamp": "2025-06-02T09:16:31.193367689"
+    },
+    "single-end - sarscov2 - [fastq]": {
+        "content": [
+            [
+                [
+                    {
+                        "id": "test",
+                        "single_end": true
+                    },
+                    "test.truncated.fastq.gz:md5,119d1b1a0a71ca6e080ff7c53ee0b690"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "test",
+                        "single_end": true
+                    },
+                    "test.settings:md5,2fd3d5d703b63ba33a83021fccf25f77"
+                ]
+            ],
+            [
+                "versions.yml:md5,00bcc9f0b864b96eeee21bc11773ee67"
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "25.04.2"
+        },
+        "timestamp": "2023-12-09T19:19:36.429445996"
+    },
+    "paired-end - sarscov2 - [fastq] -- stub": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.truncated.fastq.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                    ]
+                ],
+                "1": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.discarded.fastq.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                    ]
+                ],
+                "2": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        [
+                            "test.pair1.truncated.fastq.gz:md5,68b329da9893e34099c7d8ad5cb9c940",
+                            "test.pair2.truncated.fastq.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                        ]
+                    ]
+                ],
+                "3": [
+
+                ],
+                "4": [
+
+                ],
+                "5": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.paired.fastq.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                    ]
+                ],
+                "6": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.settings:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "7": [
+                    "versions.yml:md5,00bcc9f0b864b96eeee21bc11773ee67"
+                ],
+                "collapsed": [
+
+                ],
+                "collapsed_truncated": [
+
+                ],
+                "discarded": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.discarded.fastq.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                    ]
+                ],
+                "paired_interleaved": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.paired.fastq.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                    ]
+                ],
+                "paired_truncated": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        [
+                            "test.pair1.truncated.fastq.gz:md5,68b329da9893e34099c7d8ad5cb9c940",
+                            "test.pair2.truncated.fastq.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                        ]
+                    ]
+                ],
+                "settings": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.settings:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "singles_truncated": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.truncated.fastq.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,00bcc9f0b864b96eeee21bc11773ee67"
+                ]
+            },
+            {
+                "ADAPTERREMOVAL": {
+                    "adapterremoval": "2.3.2"
+                }
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "24.10.5"
+        },
+        "timestamp": "2025-06-02T09:16:37.301565253"
+    },
+    "paired-end - sarscov2 - [fastq]": {
+        "content": [
+            [
+                [
+                    {
+                        "id": "test",
+                        "single_end": false
+                    },
+                    [
+                        "test.pair1.truncated.fastq.gz:md5,e3da014fbb9b428e952c62e8f0fb6402",
+                        "test.pair2.truncated.fastq.gz:md5,2ebae722295ea66d84075a3b042e2b42"
+                    ]
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "test",
+                        "single_end": false
+                    },
+                    "test.settings:md5,b8a451d3981b327f3fdb44f40ba2d6d1"
+                ]
+            ],
+            [
+                "versions.yml:md5,00bcc9f0b864b96eeee21bc11773ee67"
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "25.04.2"
+        },
+        "timestamp": "2023-12-09T19:19:42.88672676"
+    },
+    "paired-end collapse - sarscov2 - [fastq]": {
+        "content": [
+            [
+                [
+                    {
+                        "id": "test",
+                        "single_end": false
+                    },
+                    [
+                        "test.pair1.truncated.fastq.gz:md5,d6113ac35457dc942e4e47d6530e1d5e",
+                        "test.pair2.truncated.fastq.gz:md5,304c48e7ad50d46acf73ae6de4014f64"
+                    ]
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "test",
+                        "single_end": false
+                    },
+                    "test.collapsed.fastq.gz:md5,369452751050a7f1e31b839702d61417"
+                ]
+            ],
+            "test.collapsed.truncated.fastq.gz",
+            [
+                [
+                    {
+                        "id": "test",
+                        "single_end": false
+                    },
+                    "test.settings:md5,7f0b2328152226e46101a535cce718b3"
+                ]
+            ],
+            [
+                "versions.yml:md5,00bcc9f0b864b96eeee21bc11773ee67"
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "25.04.2"
+        },
+        "timestamp": "2025-06-01T18:13:46.86825259"
+    },
+    "paired-end adapterlist - sarscov2 - [fastq]": {
+        "content": [
+            [
+                [
+                    {
+                        "id": "test",
+                        "single_end": false
+                    },
+                    [
+                        "test.pair1.truncated.fastq.gz:md5,e3da014fbb9b428e952c62e8f0fb6402",
+                        "test.pair2.truncated.fastq.gz:md5,2ebae722295ea66d84075a3b042e2b42"
+                    ]
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "test",
+                        "single_end": false
+                    },
+                    "test.settings:md5,36d47d9b40dbc178167d1ae0274d18f3"
+                ]
+            ],
+            [
+                "versions.yml:md5,00bcc9f0b864b96eeee21bc11773ee67"
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "25.04.2"
+        },
+        "timestamp": "2023-12-09T19:19:57.26567964"
+    }
+}

--- a/modules/nf-core/adapterremoval/tests/nextflow.config
+++ b/modules/nf-core/adapterremoval/tests/nextflow.config
@@ -1,0 +1,5 @@
+process {
+    withName: 'ADAPTERREMOVAL' {
+        ext.args = params.adapterremoval_args
+    }
+}

--- a/modules/nf-core/bowtie2/align/environment.yml
+++ b/modules/nf-core/bowtie2/align/environment.yml
@@ -1,0 +1,13 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/environment-schema.json
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  # renovate: datasource=conda depName=bioconda/bowtie2
+  - bioconda::bowtie2=2.5.4
+  # renovate: datasource=conda depName=bioconda/htslib
+  - bioconda::htslib=1.21
+  # renovate: datasource=conda depName=bioconda/samtools
+  - bioconda::samtools=1.21
+  - conda-forge::pigz=2.8

--- a/modules/nf-core/bowtie2/align/main.nf
+++ b/modules/nf-core/bowtie2/align/main.nf
@@ -1,0 +1,116 @@
+process BOWTIE2_ALIGN {
+    tag "$meta.id"
+    label 'process_high'
+
+    conda "${moduleDir}/environment.yml"
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/b4/b41b403e81883126c3227fc45840015538e8e2212f13abc9ae84e4b98891d51c/data' :
+        'community.wave.seqera.io/library/bowtie2_htslib_samtools_pigz:edeb13799090a2a6' }"
+
+    input:
+    tuple val(meta) , path(reads)
+    tuple val(meta2), path(index)
+    tuple val(meta3), path(fasta)
+    val   save_unaligned
+    val   sort_bam
+
+    output:
+    tuple val(meta), path("*.sam")      , emit: sam     , optional:true
+    tuple val(meta), path("*.bam")      , emit: bam     , optional:true
+    tuple val(meta), path("*.cram")     , emit: cram    , optional:true
+    tuple val(meta), path("*.csi")      , emit: csi     , optional:true
+    tuple val(meta), path("*.crai")     , emit: crai    , optional:true
+    tuple val(meta), path("*.log")      , emit: log
+    tuple val(meta), path("*fastq.gz")  , emit: fastq   , optional:true
+    path  "versions.yml"                , emit: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args = task.ext.args ?: ""
+    def args2 = task.ext.args2 ?: ""
+    def prefix = task.ext.prefix ?: "${meta.id}"
+
+    def unaligned = ""
+    def reads_args = ""
+    if (meta.single_end) {
+        unaligned = save_unaligned ? "--un-gz ${prefix}.unmapped.fastq.gz" : ""
+        reads_args = "-U ${reads}"
+    } else {
+        unaligned = save_unaligned ? "--un-conc-gz ${prefix}.unmapped.fastq.gz" : ""
+        reads_args = "-1 ${reads[0]} -2 ${reads[1]}"
+    }
+
+    def samtools_command = sort_bam ? 'sort' : 'view'
+    def extension_pattern = /(--output-fmt|-O)+\s+(\S+)/
+    def extension_matcher =  (args2 =~ extension_pattern)
+    def extension = extension_matcher.getCount() > 0 ? extension_matcher[0][2].toLowerCase() : "bam"
+    def reference = fasta && extension=="cram"  ? "--reference ${fasta}" : ""
+    if (!fasta && extension=="cram") error "Fasta reference is required for CRAM output"
+
+    """
+    INDEX=`find -L ./ -name "*.rev.1.bt2" | sed "s/\\.rev.1.bt2\$//"`
+    [ -z "\$INDEX" ] && INDEX=`find -L ./ -name "*.rev.1.bt2l" | sed "s/\\.rev.1.bt2l\$//"`
+    [ -z "\$INDEX" ] && echo "Bowtie2 index files not found" 1>&2 && exit 1
+
+    bowtie2 \\
+        -x \$INDEX \\
+        $reads_args \\
+        --threads $task.cpus \\
+        $unaligned \\
+        $args \\
+        2>| >(tee ${prefix}.bowtie2.log >&2) \\
+        | samtools $samtools_command $args2 --threads $task.cpus ${reference} -o ${prefix}.${extension} -
+
+    if [ -f ${prefix}.unmapped.fastq.1.gz ]; then
+        mv ${prefix}.unmapped.fastq.1.gz ${prefix}.unmapped_1.fastq.gz
+    fi
+
+    if [ -f ${prefix}.unmapped.fastq.2.gz ]; then
+        mv ${prefix}.unmapped.fastq.2.gz ${prefix}.unmapped_2.fastq.gz
+    fi
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        bowtie2: \$(echo \$(bowtie2 --version 2>&1) | sed 's/^.*bowtie2-align-s version //; s/ .*\$//')
+        samtools: \$(echo \$(samtools --version 2>&1) | sed 's/^.*samtools //; s/Using.*\$//')
+        pigz: \$( pigz --version 2>&1 | sed 's/pigz //g' )
+    END_VERSIONS
+    """
+
+    stub:
+    def args2 = task.ext.args2 ?: ""
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    def extension_pattern = /(--output-fmt|-O)+\s+(\S+)/
+    def extension = (args2 ==~ extension_pattern) ? (args2 =~ extension_pattern)[0][2].toLowerCase() : "bam"
+    def create_unmapped = ""
+    if (meta.single_end) {
+        create_unmapped = save_unaligned ? "touch ${prefix}.unmapped.fastq.gz" : ""
+    } else {
+        create_unmapped = save_unaligned ? "touch ${prefix}.unmapped_1.fastq.gz && touch ${prefix}.unmapped_2.fastq.gz" : ""
+    }
+    if (!fasta && extension=="cram") error "Fasta reference is required for CRAM output"
+
+    def create_index = ""
+    if (extension == "cram") {
+        create_index = "touch ${prefix}.crai"
+    } else if (extension == "bam") {
+        create_index = "touch ${prefix}.csi"
+    }
+
+    """
+    touch ${prefix}.${extension}
+    ${create_index}
+    touch ${prefix}.bowtie2.log
+    ${create_unmapped}
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        bowtie2: \$(echo \$(bowtie2 --version 2>&1) | sed 's/^.*bowtie2-align-s version //; s/ .*\$//')
+        samtools: \$(echo \$(samtools --version 2>&1) | sed 's/^.*samtools //; s/Using.*\$//')
+        pigz: \$( pigz --version 2>&1 | sed 's/pigz //g' )
+    END_VERSIONS
+    """
+
+}

--- a/modules/nf-core/bowtie2/align/meta.yml
+++ b/modules/nf-core/bowtie2/align/meta.yml
@@ -1,0 +1,138 @@
+name: bowtie2_align
+description: Align reads to a reference genome using bowtie2
+keywords:
+  - align
+  - map
+  - fasta
+  - fastq
+  - genome
+  - reference
+tools:
+  - bowtie2:
+      description: |
+        Bowtie 2 is an ultrafast and memory-efficient tool for aligning
+        sequencing reads to long reference sequences.
+      homepage: http://bowtie-bio.sourceforge.net/bowtie2/index.shtml
+      documentation: http://bowtie-bio.sourceforge.net/bowtie2/manual.shtml
+      doi: 10.1038/nmeth.1923
+      licence: ["GPL-3.0-or-later"]
+      identifier: ""
+input:
+  - - meta:
+        type: map
+        description: |
+          Groovy Map containing sample information
+          e.g. [ id:'test', single_end:false ]
+    - reads:
+        type: file
+        description: |
+          List of input FastQ files of size 1 and 2 for single-end and paired-end data,
+          respectively.
+        ontologies: []
+  - - meta2:
+        type: map
+        description: |
+          Groovy Map containing reference information
+          e.g. [ id:'test', single_end:false ]
+    - index:
+        type: file
+        description: Bowtie2 genome index files
+        pattern: "*.ebwt"
+        ontologies: []
+  - - meta3:
+        type: map
+        description: |
+          Groovy Map containing reference information
+          e.g. [ id:'test', single_end:false ]
+    - fasta:
+        type: file
+        description: Bowtie2 genome fasta file
+        pattern: "*.fasta"
+        ontologies: []
+  - save_unaligned:
+      type: boolean
+      description: |
+        Save reads that do not map to the reference (true) or discard them (false)
+        (default: false)
+  - sort_bam:
+      type: boolean
+      description: use samtools sort (true) or samtools view (false)
+      pattern: "true or false"
+output:
+  sam:
+    - - meta:
+          type: map
+          description: Groovy Map containing sample information
+      - "*.sam":
+          type: file
+          description: Output SAM file containing read alignments
+          pattern: "*.sam"
+          ontologies: []
+  bam:
+    - - meta:
+          type: map
+          description: Groovy Map containing sample information
+      - "*.bam":
+          type: file
+          description: Output BAM file containing read alignments
+          pattern: "*.bam"
+          ontologies: []
+  cram:
+    - - meta:
+          type: map
+          description: Groovy Map containing sample information
+      - "*.cram":
+          type: file
+          description: Output CRAM file containing read alignments
+          pattern: "*.cram"
+          ontologies: []
+  csi:
+    - - meta:
+          type: map
+          description: Groovy Map containing sample information
+      - "*.csi":
+          type: file
+          description: Output SAM/BAM index for large inputs
+          pattern: "*.csi"
+          ontologies: []
+  crai:
+    - - meta:
+          type: map
+          description: Groovy Map containing sample information
+      - "*.crai":
+          type: file
+          description: Output CRAM index
+          pattern: "*.crai"
+          ontologies: []
+  log:
+    - - meta:
+          type: map
+          description: Groovy Map containing sample information
+      - "*.log":
+          type: file
+          description: Alignment log
+          pattern: "*.log"
+          ontologies: []
+  fastq:
+    - - meta:
+          type: map
+          description: Groovy Map containing sample information
+      - "*fastq.gz":
+          type: file
+          description: Unaligned FastQ files
+          pattern: "*.fastq.gz"
+          ontologies:
+            - edam: http://edamontology.org/format_3989 # GZIP format
+  versions:
+    - versions.yml:
+        type: file
+        description: File containing software versions
+        pattern: "versions.yml"
+        ontologies:
+          - edam: http://edamontology.org/format_3750 # YAML
+authors:
+  - "@joseespinosa"
+  - "@drpatelh"
+maintainers:
+  - "@joseespinosa"
+  - "@drpatelh"

--- a/modules/nf-core/bowtie2/align/tests/cram_crai.config
+++ b/modules/nf-core/bowtie2/align/tests/cram_crai.config
@@ -1,0 +1,5 @@
+process {
+    withName: BOWTIE2_ALIGN {
+        ext.args2 = '--output-fmt cram --write-index'
+    }
+}

--- a/modules/nf-core/bowtie2/align/tests/large_index.config
+++ b/modules/nf-core/bowtie2/align/tests/large_index.config
@@ -1,0 +1,5 @@
+process {
+    withName: BOWTIE2_BUILD {
+        ext.args = '--large-index'
+    }
+}

--- a/modules/nf-core/bowtie2/align/tests/main.nf.test
+++ b/modules/nf-core/bowtie2/align/tests/main.nf.test
@@ -1,0 +1,623 @@
+nextflow_process {
+
+    name "Test Process BOWTIE2_ALIGN"
+    script "../main.nf"
+    process "BOWTIE2_ALIGN"
+    tag "modules"
+    tag "modules_nfcore"
+    tag "bowtie2"
+    tag "bowtie2/build"
+    tag "bowtie2/align"
+
+    test("sarscov2 - fastq, index, fasta, false, false - bam") {
+
+        setup {
+            run("BOWTIE2_BUILD") {
+                script "../../build/main.nf"
+                process {
+                    """
+                    input[0] = [
+                        [ id:'test'],
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true)
+                    ]
+                    """
+                }
+            }
+        }
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test', single_end:true ], // meta map
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true)
+                ]
+                input[1] = BOWTIE2_BUILD.out.index
+                input[2] = [[ id:'test'], file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true)]
+                input[3] = false //save_unaligned
+                input[4] = false //sort
+                """
+            }
+        }
+
+        then {
+            assertAll (
+                { assert process.success },
+                { assert snapshot(
+                    file(process.out.bam[0][1]).name,
+                    process.out.log,
+                    process.out.fastq,
+                    process.out.versions
+                ).match() }
+            )
+        }
+
+    }
+
+    test("sarscov2 - fastq, index, fasta, false, false - sam") {
+
+        config "./sam.config"
+        setup {
+            run("BOWTIE2_BUILD") {
+                script "../../build/main.nf"
+                process {
+                    """
+                    input[0] = [
+                        [ id:'test'],
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true)
+                    ]
+                    """
+                }
+            }
+        }
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test', single_end:true ], // meta map
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true)
+                ]
+                input[1] = BOWTIE2_BUILD.out.index
+                input[2] = [[ id:'test'], file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true)]
+                input[3] = false //save_unaligned
+                input[4] = false //sort
+                """
+            }
+        }
+
+        then {
+            assertAll (
+                { assert process.success },
+                { assert snapshot(
+                    file(process.out.sam[0][1]).readLines()[0..4],
+                    process.out.log,
+                    process.out.fastq,
+                    process.out.versions
+                ).match() }
+            )
+        }
+
+    }
+
+    test("sarscov2 - fastq, index, fasta, false, false - sam2") {
+
+        config "./sam2.config"
+        setup {
+            run("BOWTIE2_BUILD") {
+                script "../../build/main.nf"
+                process {
+                    """
+                    input[0] = [
+                        [ id:'test'],
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true)
+                    ]
+                    """
+                }
+            }
+        }
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test', single_end:true ], // meta map
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true)
+                ]
+                input[1] = BOWTIE2_BUILD.out.index
+                input[2] = [[ id:'test'], file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true)]
+                input[3] = false //save_unaligned
+                input[4] = false //sort
+                """
+            }
+        }
+
+        then {
+            assertAll (
+                { assert process.success },
+                { assert snapshot(
+                    file(process.out.sam[0][1]).readLines()[0..4],
+                    process.out.log,
+                    process.out.fastq,
+                    process.out.versions
+                ).match() }
+            )
+        }
+
+    }
+
+    test("sarscov2 - fastq, index, fasta, false, true - bam") {
+
+        setup {
+            run("BOWTIE2_BUILD") {
+                script "../../build/main.nf"
+                process {
+                    """
+                    input[0] = [
+                        [ id:'test'],
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true)
+                    ]
+                    """
+                }
+            }
+        }
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test', single_end:true ], // meta map
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true)
+                ]
+                input[1] = BOWTIE2_BUILD.out.index
+                input[2] = [[ id:'test'], file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true)]
+                input[3] = false //save_unaligned
+                input[4] = false //sort
+                """
+            }
+        }
+
+        then {
+            assertAll (
+                { assert process.success },
+                { assert snapshot(
+                    file(process.out.bam[0][1]).name,
+                    process.out.log,
+                    process.out.fastq,
+                    process.out.versions
+                ).match() }
+            )
+        }
+
+    }
+
+    test("sarscov2 - [fastq1, fastq2], index, fasta, false, false - bam") {
+
+        setup {
+            run("BOWTIE2_BUILD") {
+                script "../../build/main.nf"
+                process {
+                    """
+                    input[0] = [
+                        [ id:'test'],
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true)
+                    ]
+                    """
+                }
+            }
+        }
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test', single_end:false ], // meta map
+                    [
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true),
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_2.fastq.gz', checkIfExists: true)
+                    ]
+                ]
+                input[1] = BOWTIE2_BUILD.out.index
+                input[2] = [[ id:'test'], file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true)]
+                input[3] = false //save_unaligned
+                input[4] = false //sort
+                """
+            }
+        }
+
+        then {
+            assertAll (
+                { assert process.success },
+                { assert snapshot(
+                    file(process.out.bam[0][1]).name,
+                    process.out.log,
+                    process.out.fastq,
+                    process.out.versions
+                ).match() }
+            )
+        }
+
+    }
+
+    test("sarscov2 - [fastq1, fastq2], index, fasta, false, true - bam") {
+
+        setup {
+            run("BOWTIE2_BUILD") {
+                script "../../build/main.nf"
+                process {
+                    """
+                    input[0] = [
+                        [ id:'test'],
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true)
+                    ]
+                    """
+                }
+            }
+        }
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test', single_end:false ], // meta map
+                    [
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true),
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_2.fastq.gz', checkIfExists: true)
+                    ]
+                ]
+                input[1] = BOWTIE2_BUILD.out.index
+                input[2] = [[ id:'test'], file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true)]
+                input[3] = false //save_unaligned
+                input[4] = false //sort
+                """
+            }
+        }
+
+        then {
+            assertAll (
+                { assert process.success },
+                { assert snapshot(
+                    file(process.out.bam[0][1]).name,
+                    process.out.log,
+                    process.out.fastq,
+                    process.out.versions
+                ).match() }
+            )
+        }
+
+    }
+
+    test("sarscov2 - fastq, large_index, fasta, false, false - bam") {
+
+        config "./large_index.config"
+        setup {
+            run("BOWTIE2_BUILD") {
+                script "../../build/main.nf"
+                process {
+                    """
+                    input[0] = [
+                        [ id:'test'],
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true)
+                    ]
+                    """
+                }
+            }
+        }
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test', single_end:true ], // meta map
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true)
+                ]
+                input[1] = BOWTIE2_BUILD.out.index
+                input[2] = [[ id:'test'], file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true)]
+                input[3] = false //save_unaligned
+                input[4] = false //sort
+                """
+            }
+        }
+
+        then {
+            assertAll (
+                { assert process.success },
+                { assert snapshot(
+                    file(process.out.bam[0][1]).name,
+                    process.out.log,
+                    process.out.fastq,
+                    process.out.versions
+                ).match() }
+            )
+        }
+
+    }
+
+    test("sarscov2 - [fastq1, fastq2], large_index, fasta, false, false - bam") {
+
+        config "./large_index.config"
+        setup {
+            run("BOWTIE2_BUILD") {
+                script "../../build/main.nf"
+                process {
+                    """
+                    input[0] = [
+                        [ id:'test'],
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true)
+                    ]
+                    """
+                }
+            }
+        }
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test', single_end:false ], // meta map
+                    [
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true),
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_2.fastq.gz', checkIfExists: true)
+                    ]
+                ]
+                input[1] = BOWTIE2_BUILD.out.index
+                input[2] = [[ id:'test'], file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true)]
+                input[3] = false //save_unaligned
+                input[4] = false //sort
+                """
+            }
+        }
+
+        then {
+            assertAll (
+                { assert process.success },
+                { assert snapshot(
+                    file(process.out.bam[0][1]).name,
+                    process.out.log,
+                    process.out.fastq,
+                    process.out.versions
+                ).match() }
+            )
+        }
+
+    }
+
+    test("sarscov2 - [fastq1, fastq2], index, fasta, true, false - bam") {
+
+        setup {
+            run("BOWTIE2_BUILD") {
+                script "../../build/main.nf"
+                process {
+                    """
+                    input[0] = [
+                        [ id:'test'],
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true)
+                    ]
+                    """
+                }
+            }
+        }
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test', single_end:false ], // meta map
+                    [
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true),
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_2.fastq.gz', checkIfExists: true)
+                    ]
+                ]
+                input[1] = BOWTIE2_BUILD.out.index
+                input[2] = [[ id:'test'], file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true)]
+                input[3] = false //save_unaligned
+                input[4] = false //sort
+                """
+            }
+        }
+
+        then {
+            assertAll (
+                { assert process.success },
+                { assert snapshot(
+                    file(process.out.bam[0][1]).name,
+                    process.out.log,
+                    process.out.fastq,
+                    process.out.versions
+                ).match() }
+            )
+        }
+
+    }
+
+    test("sarscov2 - fastq, index, fasta, true, false - bam") {
+
+        setup {
+            run("BOWTIE2_BUILD") {
+                script "../../build/main.nf"
+                process {
+                    """
+                    input[0] = [
+                        [ id:'test'],
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true)
+                    ]
+                    """
+                }
+            }
+        }
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test', single_end:true ], // meta map
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true)
+                ]
+                input[1] = BOWTIE2_BUILD.out.index
+                input[2] = [[ id:'test'], file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true)]
+                input[3] = false //save_unaligned
+                input[4] = false //sort
+                """
+            }
+        }
+
+        then {
+            assertAll (
+                { assert process.success },
+                { assert snapshot(
+                    file(process.out.bam[0][1]).name,
+                    process.out.log,
+                    process.out.fastq,
+                    process.out.versions
+                ).match() }
+
+            )
+        }
+
+    }
+
+    test("sarscov2 - [fastq1, fastq2], index, fasta, true, true - cram") {
+
+        config "./cram_crai.config"
+        setup {
+            run("BOWTIE2_BUILD") {
+                script "../../build/main.nf"
+                process {
+                    """
+                    input[0] = [
+                        [ id:'test'],
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true)
+                    ]
+                    """
+                }
+            }
+        }
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test', single_end:false ], // meta map
+                    [
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true),
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_2.fastq.gz', checkIfExists: true)
+                    ]
+                ]
+                input[1] = BOWTIE2_BUILD.out.index
+                input[2] = [[ id:'test'], file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true)]
+                input[3] = false //save_unaligned
+                input[4] = true //sort
+                """
+            }
+        }
+
+        then {
+            assertAll (
+                { assert process.success },
+                { assert snapshot(
+                    file(process.out.cram[0][1]).name,
+                    file(process.out.crai[0][1]).name
+                ).match() }
+            )
+        }
+
+    }
+
+    test("sarscov2 - [fastq1, fastq2], index, fasta, false, false - stub") {
+
+        options "-stub"
+        setup {
+            run("BOWTIE2_BUILD") {
+                script "../../build/main.nf"
+                process {
+                    """
+                    input[0] = [
+                        [ id:'test'],
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true)
+                    ]
+                    """
+                }
+            }
+        }
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test', single_end:false ], // meta map
+                    [
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true),
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_2.fastq.gz', checkIfExists: true)
+                    ]
+                ]
+                input[1] = BOWTIE2_BUILD.out.index
+                input[2] = [[ id:'test'], file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true)]
+                input[3] = false //save_unaligned
+                input[4] = false //sort
+                """
+            }
+        }
+
+        then {
+            assertAll (
+                { assert process.success },
+                { assert snapshot(
+                    file(process.out.bam[0][1]).name,
+                    file(process.out.csi[0][1]).name,
+                    file(process.out.log[0][1]).name,
+                    process.out.fastq,
+                    process.out.versions
+                ).match() }
+            )
+        }
+
+    }
+
+    test("sarscov2 - fastq, index, fasta, true, false - stub") {
+
+        options "-stub"
+        setup {
+            run("BOWTIE2_BUILD") {
+                script "../../build/main.nf"
+                process {
+                    """
+                    input[0] = [
+                        [ id:'test'],
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true)
+                    ]
+                    """
+                }
+            }
+        }
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test', single_end:true ], // meta map
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true)
+                ]
+                input[1] = BOWTIE2_BUILD.out.index
+                input[2] = [[ id:'test'], file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true)]
+                input[3] = false //save_unaligned
+                input[4] = false //sort
+                """
+            }
+        }
+
+        then {
+            assertAll (
+                { assert process.success },
+                { assert snapshot(
+                    file(process.out.bam[0][1]).name,
+                    file(process.out.csi[0][1]).name,
+                    file(process.out.log[0][1]).name,
+                    process.out.fastq,
+                    process.out.versions
+                ).match() }
+            )
+        }
+
+    }
+
+}

--- a/modules/nf-core/bowtie2/align/tests/main.nf.test.snap
+++ b/modules/nf-core/bowtie2/align/tests/main.nf.test.snap
@@ -1,0 +1,311 @@
+{
+    "sarscov2 - [fastq1, fastq2], large_index, fasta, false, false - bam": {
+        "content": [
+            "test.bam",
+            [
+                [
+                    {
+                        "id": "test",
+                        "single_end": false
+                    },
+                    "test.bowtie2.log:md5,bd89ce1b28c93bf822bae391ffcedd19"
+                ]
+            ],
+            [
+                
+            ],
+            [
+                "versions.yml:md5,2768d626cdb54c9a9b5ed7aecbc3ca11"
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "24.10.4"
+        },
+        "timestamp": "2025-03-24T12:45:59.038637"
+    },
+    "sarscov2 - fastq, index, fasta, false, false - sam2": {
+        "content": [
+            [
+                "ERR5069949.2151832\t16\tMT192765.1\t17453\t42\t150M\t*\t0\t0\tACGCACATTGCTAACTAAGGGCACACTAGAACCAGAATATTTCAATTCAGTGTGTAGACTTATGAAAACTATAGGTCCAGACATGTTCCTCGGAACTTGTCGGCGTTGTCCTGCTGAAATTGTTGACACTGTGAGTGCTTTGGTTTATGA\tAAAA<EEEEEEAEEEAEAAAAEEEEEEEEEAAAEE<EEEEEAAEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEAEEEEAAEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEAAAAAA\tAS:i:0\tXN:i:0\tXM:i:0\tXO:i:0\tXG:i:0\tNM:i:0\tMD:Z:150\tYT:Z:UU",
+                "ERR5069949.576388\t16\tMT192765.1\t5798\t42\t77M\t*\t0\t0\tGCATAGACGGTGCTTTACTTACAAAGTCCTCAGAATACAAAGGTCCTATTACGGATGTTTTCTACAAAGAAAACAGT\tEA/AEEE/<EEEEEEEEEEEAA<EEEEEEEEEEEEEEEEEEEEEAEEEEEAEEEAEE6/EEEAEEEEEEEEEA6AAA\tAS:i:0\tXN:i:0\tXM:i:0\tXO:i:0\tXG:i:0\tNM:i:0\tMD:Z:77\tYT:Z:UU",
+                "ERR5069949.501486\t16\tMT192765.1\t5423\t42\t146M\t*\t0\t0\tTAGGTGAGTTAGGTGATGTTAGAGAAACAATGAGTTACTTGTTTCAACATGCCAATTTAGATTCTTGCAAAAGAGTCTTGAACGTGGTGTGTAAAACTTGTGGACAACAGCAGACAACCCTTAAGGGTGTAGAAGCTGTTATGTAC\tEAAAAEAEEEE6E<AEEEEEEEE<EEEEEEAAEE/EEEEEE/<EEEEEEAEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEAEEEEEEEEEEAEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEAAAAA\tAS:i:0\tXN:i:0\tXM:i:0\tXO:i:0\tXG:i:0\tNM:i:0\tMD:Z:146\tYT:Z:UU",
+                "ERR5069949.1331889\t0\tMT192765.1\t13010\t42\t132M\t*\t0\t0\tGTCTACAAGCTGGTAATGCAACAGAAGTGCCTGCCAATTCAACTGTATTATCTTTCTGTGCTTTTGCTGTAGATGCTGCTAAAGCTTACAAAGATTATCTAGCTAGTGGGGGACAACCAATCACTAATTGTG\tA/AAAEEEEEEEEEEEEEEEEEEEAEEEEAEEEEEEEEEEEAEEEEEEEEEEEEEEE/EEEEE<AEAEEEEE/EAEAEEE/AEEEEEEEEEEEEEEEEEEEEAE/EEEEEEEEEEEEEEEEEEEEEEEA<EE\tAS:i:0\tXN:i:0\tXM:i:0\tXO:i:0\tXG:i:0\tNM:i:0\tMD:Z:132\tYT:Z:UU",
+                "ERR5069949.2161340\t0\tMT192765.1\t17482\t42\t80M\t*\t0\t0\tAACCAGAATATTTCAATTCAGTGTGTAGACTTATGAAAACTATAGGTCCAGACATGTTCCTCGGAACTTGTCGGCGTTGT\tA/AA//EEAEA/E/AEEEE6EE/EEEA/6AEEEEEEEEE6EEEAEAEE//A/EEEEEE//E/E/A//E/E/<<EE</E/E\tAS:i:0\tXN:i:0\tXM:i:0\tXO:i:0\tXG:i:0\tNM:i:0\tMD:Z:80\tYT:Z:UU"
+            ],
+            [
+                [
+                    {
+                        "id": "test",
+                        "single_end": true
+                    },
+                    "test.bowtie2.log:md5,7b8a9e61b7646da1089b041333c41a87"
+                ]
+            ],
+            [
+                
+            ],
+            [
+                "versions.yml:md5,2768d626cdb54c9a9b5ed7aecbc3ca11"
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "24.10.5"
+        },
+        "timestamp": "2025-03-25T08:28:51.065380563"
+    },
+    "sarscov2 - [fastq1, fastq2], index, fasta, true, true - cram": {
+        "content": [
+            "test.cram",
+            "test.cram.crai"
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "23.10.1"
+        },
+        "timestamp": "2024-03-19T08:46:08.033126014"
+    },
+    "sarscov2 - fastq, index, fasta, false, false - bam": {
+        "content": [
+            "test.bam",
+            [
+                [
+                    {
+                        "id": "test",
+                        "single_end": true
+                    },
+                    "test.bowtie2.log:md5,7b8a9e61b7646da1089b041333c41a87"
+                ]
+            ],
+            [
+                
+            ],
+            [
+                "versions.yml:md5,2768d626cdb54c9a9b5ed7aecbc3ca11"
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "24.10.4"
+        },
+        "timestamp": "2025-03-24T11:38:12.222762"
+    },
+    "sarscov2 - fastq, index, fasta, true, false - bam": {
+        "content": [
+            "test.bam",
+            [
+                [
+                    {
+                        "id": "test",
+                        "single_end": true
+                    },
+                    "test.bowtie2.log:md5,7b8a9e61b7646da1089b041333c41a87"
+                ]
+            ],
+            [
+                
+            ],
+            [
+                "versions.yml:md5,2768d626cdb54c9a9b5ed7aecbc3ca11"
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "24.10.4"
+        },
+        "timestamp": "2025-03-24T12:46:12.766061"
+    },
+    "sarscov2 - fastq, large_index, fasta, false, false - bam": {
+        "content": [
+            "test.bam",
+            [
+                [
+                    {
+                        "id": "test",
+                        "single_end": true
+                    },
+                    "test.bowtie2.log:md5,7b8a9e61b7646da1089b041333c41a87"
+                ]
+            ],
+            [
+                
+            ],
+            [
+                "versions.yml:md5,2768d626cdb54c9a9b5ed7aecbc3ca11"
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "24.10.4"
+        },
+        "timestamp": "2025-03-24T11:24:03.499074"
+    },
+    "sarscov2 - fastq, index, fasta, false, true - bam": {
+        "content": [
+            "test.bam",
+            [
+                [
+                    {
+                        "id": "test",
+                        "single_end": true
+                    },
+                    "test.bowtie2.log:md5,7b8a9e61b7646da1089b041333c41a87"
+                ]
+            ],
+            [
+                
+            ],
+            [
+                "versions.yml:md5,2768d626cdb54c9a9b5ed7aecbc3ca11"
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "24.10.4"
+        },
+        "timestamp": "2025-03-24T11:08:30.329879"
+    },
+    "sarscov2 - fastq, index, fasta, true, false - stub": {
+        "content": [
+            "test.bam",
+            "test.csi",
+            "test.bowtie2.log",
+            [
+                
+            ],
+            [
+                "versions.yml:md5,2768d626cdb54c9a9b5ed7aecbc3ca11"
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "24.10.4"
+        },
+        "timestamp": "2025-03-24T13:48:54.684859"
+    },
+    "sarscov2 - [fastq1, fastq2], index, fasta, false, false - bam": {
+        "content": [
+            "test.bam",
+            [
+                [
+                    {
+                        "id": "test",
+                        "single_end": false
+                    },
+                    "test.bowtie2.log:md5,bd89ce1b28c93bf822bae391ffcedd19"
+                ]
+            ],
+            [
+                
+            ],
+            [
+                "versions.yml:md5,2768d626cdb54c9a9b5ed7aecbc3ca11"
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "24.10.4"
+        },
+        "timestamp": "2025-03-24T11:13:41.815354"
+    },
+    "sarscov2 - [fastq1, fastq2], index, fasta, false, false - stub": {
+        "content": [
+            "test.bam",
+            "test.csi",
+            "test.bowtie2.log",
+            [
+                
+            ],
+            [
+                "versions.yml:md5,2768d626cdb54c9a9b5ed7aecbc3ca11"
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "24.10.4"
+        },
+        "timestamp": "2025-03-24T13:06:00.821232"
+    },
+    "sarscov2 - fastq, index, fasta, false, false - sam": {
+        "content": [
+            [
+                "ERR5069949.2151832\t16\tMT192765.1\t17453\t42\t150M\t*\t0\t0\tACGCACATTGCTAACTAAGGGCACACTAGAACCAGAATATTTCAATTCAGTGTGTAGACTTATGAAAACTATAGGTCCAGACATGTTCCTCGGAACTTGTCGGCGTTGTCCTGCTGAAATTGTTGACACTGTGAGTGCTTTGGTTTATGA\tAAAA<EEEEEEAEEEAEAAAAEEEEEEEEEAAAEE<EEEEEAAEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEAEEEEAAEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEAAAAAA\tAS:i:0\tXN:i:0\tXM:i:0\tXO:i:0\tXG:i:0\tNM:i:0\tMD:Z:150\tYT:Z:UU",
+                "ERR5069949.576388\t16\tMT192765.1\t5798\t42\t77M\t*\t0\t0\tGCATAGACGGTGCTTTACTTACAAAGTCCTCAGAATACAAAGGTCCTATTACGGATGTTTTCTACAAAGAAAACAGT\tEA/AEEE/<EEEEEEEEEEEAA<EEEEEEEEEEEEEEEEEEEEEAEEEEEAEEEAEE6/EEEAEEEEEEEEEA6AAA\tAS:i:0\tXN:i:0\tXM:i:0\tXO:i:0\tXG:i:0\tNM:i:0\tMD:Z:77\tYT:Z:UU",
+                "ERR5069949.501486\t16\tMT192765.1\t5423\t42\t146M\t*\t0\t0\tTAGGTGAGTTAGGTGATGTTAGAGAAACAATGAGTTACTTGTTTCAACATGCCAATTTAGATTCTTGCAAAAGAGTCTTGAACGTGGTGTGTAAAACTTGTGGACAACAGCAGACAACCCTTAAGGGTGTAGAAGCTGTTATGTAC\tEAAAAEAEEEE6E<AEEEEEEEE<EEEEEEAAEE/EEEEEE/<EEEEEEAEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEAEEEEEEEEEEAEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEAAAAA\tAS:i:0\tXN:i:0\tXM:i:0\tXO:i:0\tXG:i:0\tNM:i:0\tMD:Z:146\tYT:Z:UU",
+                "ERR5069949.1331889\t0\tMT192765.1\t13010\t42\t132M\t*\t0\t0\tGTCTACAAGCTGGTAATGCAACAGAAGTGCCTGCCAATTCAACTGTATTATCTTTCTGTGCTTTTGCTGTAGATGCTGCTAAAGCTTACAAAGATTATCTAGCTAGTGGGGGACAACCAATCACTAATTGTG\tA/AAAEEEEEEEEEEEEEEEEEEEAEEEEAEEEEEEEEEEEAEEEEEEEEEEEEEEE/EEEEE<AEAEEEEE/EAEAEEE/AEEEEEEEEEEEEEEEEEEEEAE/EEEEEEEEEEEEEEEEEEEEEEEA<EE\tAS:i:0\tXN:i:0\tXM:i:0\tXO:i:0\tXG:i:0\tNM:i:0\tMD:Z:132\tYT:Z:UU",
+                "ERR5069949.2161340\t0\tMT192765.1\t17482\t42\t80M\t*\t0\t0\tAACCAGAATATTTCAATTCAGTGTGTAGACTTATGAAAACTATAGGTCCAGACATGTTCCTCGGAACTTGTCGGCGTTGT\tA/AA//EEAEA/E/AEEEE6EE/EEEA/6AEEEEEEEEE6EEEAEAEE//A/EEEEEE//E/E/A//E/E/<<EE</E/E\tAS:i:0\tXN:i:0\tXM:i:0\tXO:i:0\tXG:i:0\tNM:i:0\tMD:Z:80\tYT:Z:UU"
+            ],
+            [
+                [
+                    {
+                        "id": "test",
+                        "single_end": true
+                    },
+                    "test.bowtie2.log:md5,7b8a9e61b7646da1089b041333c41a87"
+                ]
+            ],
+            [
+                
+            ],
+            [
+                "versions.yml:md5,2768d626cdb54c9a9b5ed7aecbc3ca11"
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "24.10.5"
+        },
+        "timestamp": "2025-03-25T08:28:26.086145568"
+    },
+    "sarscov2 - [fastq1, fastq2], index, fasta, true, false - bam": {
+        "content": [
+            "test.bam",
+            [
+                [
+                    {
+                        "id": "test",
+                        "single_end": false
+                    },
+                    "test.bowtie2.log:md5,bd89ce1b28c93bf822bae391ffcedd19"
+                ]
+            ],
+            [
+                
+            ],
+            [
+                "versions.yml:md5,2768d626cdb54c9a9b5ed7aecbc3ca11"
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "24.10.4"
+        },
+        "timestamp": "2025-03-24T12:46:05.840695"
+    },
+    "sarscov2 - [fastq1, fastq2], index, fasta, false, true - bam": {
+        "content": [
+            "test.bam",
+            [
+                [
+                    {
+                        "id": "test",
+                        "single_end": false
+                    },
+                    "test.bowtie2.log:md5,bd89ce1b28c93bf822bae391ffcedd19"
+                ]
+            ],
+            [
+                
+            ],
+            [
+                "versions.yml:md5,2768d626cdb54c9a9b5ed7aecbc3ca11"
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "24.10.4"
+        },
+        "timestamp": "2025-03-24T11:18:52.825034"
+    }
+}

--- a/modules/nf-core/bowtie2/align/tests/sam.config
+++ b/modules/nf-core/bowtie2/align/tests/sam.config
@@ -1,0 +1,5 @@
+process {
+    withName: BOWTIE2_ALIGN {
+        ext.args2 = '--output-fmt SAM'
+    }
+}

--- a/modules/nf-core/bowtie2/align/tests/sam2.config
+++ b/modules/nf-core/bowtie2/align/tests/sam2.config
@@ -1,0 +1,5 @@
+process {
+    withName: BOWTIE2_ALIGN {
+        ext.args2 = '-O SAM'
+    }
+}

--- a/modules/nf-core/bowtie2/build/environment.yml
+++ b/modules/nf-core/bowtie2/build/environment.yml
@@ -1,0 +1,13 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/environment-schema.json
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  # renovate: datasource=conda depName=bioconda/bowtie2
+  - bioconda::bowtie2=2.5.4
+  # renovate: datasource=conda depName=bioconda/htslib
+  - bioconda::htslib=1.21
+  # renovate: datasource=conda depName=bioconda/samtools
+  - bioconda::samtools=1.21
+  - conda-forge::pigz=2.8

--- a/modules/nf-core/bowtie2/build/main.nf
+++ b/modules/nf-core/bowtie2/build/main.nf
@@ -1,0 +1,42 @@
+process BOWTIE2_BUILD {
+    tag "$fasta"
+    label 'process_high'
+
+    conda "${moduleDir}/environment.yml"
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/b4/b41b403e81883126c3227fc45840015538e8e2212f13abc9ae84e4b98891d51c/data' :
+        'community.wave.seqera.io/library/bowtie2_htslib_samtools_pigz:edeb13799090a2a6' }"
+
+    input:
+    tuple val(meta), path(fasta)
+
+    output:
+    tuple val(meta), path('bowtie2')    , emit: index
+    path "versions.yml"                 , emit: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args = task.ext.args ?: ''
+    """
+    mkdir bowtie2
+    bowtie2-build $args --threads $task.cpus $fasta bowtie2/${fasta.baseName}
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        bowtie2: \$(echo \$(bowtie2 --version 2>&1) | sed 's/^.*bowtie2-align-s version //; s/ .*\$//')
+    END_VERSIONS
+    """
+
+    stub:
+    """
+    mkdir bowtie2
+    touch bowtie2/${fasta.baseName}.{1..4}.bt2
+    touch bowtie2/${fasta.baseName}.rev.{1,2}.bt2
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        bowtie2: \$(echo \$(bowtie2 --version 2>&1) | sed 's/^.*bowtie2-align-s version //; s/ .*\$//')
+    END_VERSIONS
+    """
+}

--- a/modules/nf-core/bowtie2/build/meta.yml
+++ b/modules/nf-core/bowtie2/build/meta.yml
@@ -1,0 +1,53 @@
+name: bowtie2_build
+description: Builds bowtie index for reference genome
+keywords:
+  - build
+  - index
+  - fasta
+  - genome
+  - reference
+tools:
+  - bowtie2:
+      description: |
+        Bowtie 2 is an ultrafast and memory-efficient tool for aligning
+        sequencing reads to long reference sequences.
+      homepage: http://bowtie-bio.sourceforge.net/bowtie2/index.shtml
+      documentation: http://bowtie-bio.sourceforge.net/bowtie2/manual.shtml
+      doi: 10.1038/nmeth.1923
+      licence: ["GPL-3.0-or-later"]
+      identifier: ""
+input:
+  - - meta:
+        type: map
+        description: |
+          Groovy Map containing reference information
+          e.g. [ id:'test', single_end:false ]
+    - fasta:
+        type: file
+        description: Input genome fasta file
+        ontologies: []
+output:
+  index:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing reference information
+            e.g. [ id:'test', single_end:false ]
+      - bowtie2:
+          type: file
+          description: Bowtie2 genome index files
+          pattern: "*.bt2"
+          ontologies: []
+  versions:
+    - versions.yml:
+        type: file
+        description: File containing software versions
+        pattern: "versions.yml"
+        ontologies:
+          - edam: http://edamontology.org/format_3750 # YAML
+authors:
+  - "@joseespinosa"
+  - "@drpatelh"
+maintainers:
+  - "@joseespinosa"
+  - "@drpatelh"

--- a/modules/nf-core/bowtie2/build/tests/main.nf.test
+++ b/modules/nf-core/bowtie2/build/tests/main.nf.test
@@ -1,0 +1,31 @@
+nextflow_process {
+
+    name "Test Process BOWTIE2_BUILD"
+    script "../main.nf"
+    process "BOWTIE2_BUILD"
+    tag "modules"
+    tag "modules_nfcore"
+    tag "bowtie2"
+    tag "bowtie2/build"
+
+    test("Should run without failures") {
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test' ],
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true)
+                ]
+                """
+            }
+        }
+
+        then {
+            assert process.success
+            assert snapshot(process.out).match()
+        }
+
+    }
+
+}

--- a/modules/nf-core/bowtie2/build/tests/main.nf.test.snap
+++ b/modules/nf-core/bowtie2/build/tests/main.nf.test.snap
@@ -1,0 +1,49 @@
+{
+    "Should run without failures": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        [
+                            "genome.1.bt2:md5,cbe3d0bbea55bc57c99b4bfa25b5fbdf",
+                            "genome.2.bt2:md5,47b153cd1319abc88dda532462651fcf",
+                            "genome.3.bt2:md5,4ed93abba181d8dfab2e303e33114777",
+                            "genome.4.bt2:md5,c25be5f8b0378abf7a58c8a880b87626",
+                            "genome.rev.1.bt2:md5,52be6950579598a990570fbcf5372184",
+                            "genome.rev.2.bt2:md5,e3b4ef343dea4dd571642010a7d09597"
+                        ]
+                    ]
+                ],
+                "1": [
+                    "versions.yml:md5,d136fb9c16f0a9fb2ae804b2a5fbc09c"
+                ],
+                "index": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        [
+                            "genome.1.bt2:md5,cbe3d0bbea55bc57c99b4bfa25b5fbdf",
+                            "genome.2.bt2:md5,47b153cd1319abc88dda532462651fcf",
+                            "genome.3.bt2:md5,4ed93abba181d8dfab2e303e33114777",
+                            "genome.4.bt2:md5,c25be5f8b0378abf7a58c8a880b87626",
+                            "genome.rev.1.bt2:md5,52be6950579598a990570fbcf5372184",
+                            "genome.rev.2.bt2:md5,e3b4ef343dea4dd571642010a7d09597"
+                        ]
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,d136fb9c16f0a9fb2ae804b2a5fbc09c"
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "25.02.1"
+        },
+        "timestamp": "2023-11-23T11:51:01.107681997"
+    }
+}

--- a/modules/nf-core/falco/environment.yml
+++ b/modules/nf-core/falco/environment.yml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/environment-schema.json
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  - bioconda::falco=1.2.1

--- a/modules/nf-core/falco/main.nf
+++ b/modules/nf-core/falco/main.nf
@@ -1,0 +1,57 @@
+process FALCO {
+    tag "$meta.id"
+    label 'process_single'
+
+
+    conda "${moduleDir}/environment.yml"
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/falco:1.2.1--h867801b_3':
+        'biocontainers/falco:1.2.1--h867801b_3' }"
+
+    input:
+    tuple val(meta), path(reads)
+
+    output:
+    tuple val(meta), path("*.html"), emit: html
+    tuple val(meta), path("*.txt") , emit: txt
+    path  "versions.yml"           , emit: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args = task.ext.args ?: ''
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    if ( reads.toList().size() == 1 ) {
+        """
+        falco $args --threads $task.cpus ${reads} -D ${prefix}_fastqc_data.txt -S ${prefix}_summary.txt -R ${prefix}_report.html
+
+        cat <<-END_VERSIONS > versions.yml
+        "${task.process}":
+            falco:\$( falco --version | sed -e "s/falco//g" )
+        END_VERSIONS
+        """
+    } else {
+        """
+        falco $args --threads $task.cpus ${reads}
+
+        cat <<-END_VERSIONS > versions.yml
+        "${task.process}":
+            falco:\$( falco --version | sed -e "s/falco//g" )
+        END_VERSIONS
+        """
+    }
+
+    stub:
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    """
+    touch ${prefix}_data.txt
+    touch ${prefix}_fastqc_data.html
+    touch ${prefix}_summary.txt
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        falco: \$( falco --version | sed -e "s/falco v//g" )
+    END_VERSIONS
+    """
+}

--- a/modules/nf-core/falco/meta.yml
+++ b/modules/nf-core/falco/meta.yml
@@ -1,0 +1,61 @@
+name: falco
+description: Run falco on sequenced reads
+keywords:
+  - quality control
+  - qc
+  - adapters
+  - fastq
+tools:
+  - fastqc:
+      description: "falco is a drop-in C++ implementation of FastQC to assess the quality
+        of sequence reads."
+      homepage: "https://falco.readthedocs.io/"
+      documentation: "https://falco.readthedocs.io/"
+      licence: ["GPL v3"]
+      identifier: biotools:falco-rna
+input:
+  - - meta:
+        type: map
+        description: |
+          Groovy Map containing sample information
+          e.g. [ id:'test', single_end:false ]
+    - reads:
+        type: file
+        description: |
+          List of input FastQ files of size 1 and 2 for single-end and paired-end data,
+          respectively.
+        ontologies: []
+output:
+  html:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. [ id:'test', single_end:false ]
+      - "*.html":
+          type: file
+          description: FastQC like report
+          pattern: "*_{fastqc_report.html}"
+          ontologies: []
+  txt:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. [ id:'test', single_end:false ]
+      - "*.txt":
+          type: file
+          description: falco report data
+          pattern: "*_{data.txt}"
+          ontologies: []
+  versions:
+    - versions.yml:
+        type: file
+        description: File containing software versions
+        pattern: "versions.yml"
+        ontologies:
+          - edam: http://edamontology.org/format_3750 # YAML
+authors:
+  - "@lucacozzuto"
+maintainers:
+  - "@lucacozzuto"

--- a/modules/nf-core/falco/tests/main.nf.test
+++ b/modules/nf-core/falco/tests/main.nf.test
@@ -1,0 +1,108 @@
+nextflow_process {
+
+    name "Test Process FALCO"
+    script "../main.nf"
+    process "FALCO"
+
+    tag "modules"
+    tag "modules_nfcore"
+    tag "falco"
+
+    test("sarscov2 - fastq - single end") {
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id: 'test', single_end:true ],
+                    [
+                        file(
+                            params.test_data['sarscov2']['illumina']['test_1_fastq_gz'],
+                            checkIfExists: true
+                        ),
+                    ],
+                ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(
+                    process.out.txt,
+                    file(process.out.html.get(0).get(1)).list(),
+                    ).match()
+                },
+            )
+        }
+
+    }
+
+    test("sarscov2 - fastq - paired end") {
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id: 'test', single_end:false ],
+                    [
+                        file(
+                            params.test_data['sarscov2']['illumina']['test_1_fastq_gz'],
+                            checkIfExists: true
+                        ),
+                        file(
+                            params.test_data['sarscov2']['illumina']['test_2_fastq_gz'],
+                            checkIfExists: true
+                        ),
+                    ],
+                ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(
+                    process.out.txt,
+                    process.out.html.get(0).get(1).collect{ it.split("/")[-1] }.sort(),
+                    ).match()
+                },
+            )
+        }
+
+    }
+
+    test("sarscov2 - fastq - interleaved") {
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id: 'test', single_end:false ],
+                    [
+                        file(
+                            params.test_data['sarscov2']['illumina']['test_interleaved_fastq_gz'],
+                            checkIfExists: true
+                        ),
+                    ],
+                ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(
+                    process.out.txt,
+                    file(process.out.html.get(0).get(1)).list(),
+                    ).match()
+                },
+            )
+        }
+
+    }
+
+}

--- a/modules/nf-core/falco/tests/main.nf.test.snap
+++ b/modules/nf-core/falco/tests/main.nf.test.snap
@@ -1,0 +1,61 @@
+{
+    "sarscov2 - fastq - single end": {
+        "content": [
+            [
+                [
+                    {
+                        "id": "test",
+                        "single_end": true
+                    },
+                    [
+                        "test_fastqc_data.txt:md5,36d989bb9e2d5a632e19452f4e6c2a4e",
+                        "test_summary.txt:md5,a925aec214a83d2f6252847166f2ef3a"
+                    ]
+                ]
+            ],
+            null
+        ],
+        "timestamp": "2024-02-02T16:28:17.756764"
+    },
+    "sarscov2 - fastq - paired end": {
+        "content": [
+            [
+                [
+                    {
+                        "id": "test",
+                        "single_end": false
+                    },
+                    [
+                        "test_1.fastq.gz_fastqc_data.txt:md5,36d989bb9e2d5a632e19452f4e6c2a4e",
+                        "test_1.fastq.gz_summary.txt:md5,a925aec214a83d2f6252847166f2ef3a",
+                        "test_2.fastq.gz_fastqc_data.txt:md5,ad5c45dfc8f79754dd5d8029456b715b",
+                        "test_2.fastq.gz_summary.txt:md5,d0cb642adefb5635a25e808f1f38780a"
+                    ]
+                ]
+            ],
+            [
+                "test_1.fastq.gz_fastqc_report.html",
+                "test_2.fastq.gz_fastqc_report.html"
+            ]
+        ],
+        "timestamp": "2024-02-02T16:22:11.757473"
+    },
+    "sarscov2 - fastq - interleaved": {
+        "content": [
+            [
+                [
+                    {
+                        "id": "test",
+                        "single_end": false
+                    },
+                    [
+                        "test_fastqc_data.txt:md5,b5e593f140fe578bdd25ceb84e98fd37",
+                        "test_summary.txt:md5,ca52f458b1223d89db69e2d5e73cf867"
+                    ]
+                ]
+            ],
+            null
+        ],
+        "timestamp": "2024-02-02T16:28:36.035899"
+    }
+}

--- a/modules/nf-core/fastp/environment.yml
+++ b/modules/nf-core/fastp/environment.yml
@@ -1,0 +1,8 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/environment-schema.json
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  # renovate: datasource=conda depName=bioconda/fastp
+  - bioconda::fastp=1.0.1

--- a/modules/nf-core/fastp/environment.yml
+++ b/modules/nf-core/fastp/environment.yml
@@ -4,5 +4,4 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
-  # renovate: datasource=conda depName=bioconda/fastp
-  - bioconda::fastp=1.0.1
+  - bioconda::fastp=0.24.0

--- a/modules/nf-core/fastp/main.nf
+++ b/modules/nf-core/fastp/main.nf
@@ -1,0 +1,104 @@
+process FASTP {
+    tag "$meta.id"
+    label 'process_medium'
+
+    conda "${moduleDir}/environment.yml"
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/52/527b18847a97451091dba07a886b24f17f742a861f9f6c9a6bfb79d4f1f3bf9d/data' :
+        'community.wave.seqera.io/library/fastp:1.0.1--c8b87fe62dcc103c' }"
+
+    input:
+    tuple val(meta), path(reads), path(adapter_fasta)
+    val   discard_trimmed_pass
+    val   save_trimmed_fail
+    val   save_merged
+
+    output:
+    tuple val(meta), path('*.fastp.fastq.gz') , optional:true, emit: reads
+    tuple val(meta), path('*.json')           , emit: json
+    tuple val(meta), path('*.html')           , emit: html
+    tuple val(meta), path('*.log')            , emit: log
+    tuple val(meta), path('*.fail.fastq.gz')  , optional:true, emit: reads_fail
+    tuple val(meta), path('*.merged.fastq.gz'), optional:true, emit: reads_merged
+    tuple val("${task.process}"), val('fastp'), eval('fastp --version 2>&1 | sed -e "s/fastp //g"'), emit: versions_fastp, topic: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args = task.ext.args ?: ''
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    def adapter_list = adapter_fasta ? "--adapter_fasta ${adapter_fasta}" : ""
+    def fail_fastq = save_trimmed_fail && meta.single_end ? "--failed_out ${prefix}.fail.fastq.gz" : save_trimmed_fail && !meta.single_end ? "--failed_out ${prefix}.paired.fail.fastq.gz --unpaired1 ${prefix}_R1.fail.fastq.gz --unpaired2 ${prefix}_R2.fail.fastq.gz" : ''
+    def out_fq1 = discard_trimmed_pass ?: ( meta.single_end ? "--out1 ${prefix}.fastp.fastq.gz" : "--out1 ${prefix}_R1.fastp.fastq.gz" )
+    def out_fq2 = discard_trimmed_pass ?: "--out2 ${prefix}_R2.fastp.fastq.gz"
+    // Added soft-links to original fastqs for consistent naming in MultiQC
+    // Use single ended for interleaved. Add --interleaved_in in config.
+    if ( task.ext.args?.contains('--interleaved_in') ) {
+        """
+        [ ! -f  ${prefix}.fastq.gz ] && ln -sf $reads ${prefix}.fastq.gz
+
+        fastp \\
+            --stdout \\
+            --in1 ${prefix}.fastq.gz \\
+            --thread $task.cpus \\
+            --json ${prefix}.fastp.json \\
+            --html ${prefix}.fastp.html \\
+            $adapter_list \\
+            $fail_fastq \\
+            $args \\
+            2>| >(tee ${prefix}.fastp.log >&2) \\
+        | gzip -c > ${prefix}.fastp.fastq.gz
+        """
+    } else if (meta.single_end) {
+        """
+        [ ! -f  ${prefix}.fastq.gz ] && ln -sf $reads ${prefix}.fastq.gz
+
+        fastp \\
+            --in1 ${prefix}.fastq.gz \\
+            $out_fq1 \\
+            --thread $task.cpus \\
+            --json ${prefix}.fastp.json \\
+            --html ${prefix}.fastp.html \\
+            $adapter_list \\
+            $fail_fastq \\
+            $args \\
+            2>| >(tee ${prefix}.fastp.log >&2)
+        """
+    } else {
+        def merge_fastq = save_merged ? "-m --merged_out ${prefix}.merged.fastq.gz" : ''
+        """
+        [ ! -f  ${prefix}_R1.fastq.gz ] && ln -sf ${reads[0]} ${prefix}_R1.fastq.gz
+        [ ! -f  ${prefix}_R2.fastq.gz ] && ln -sf ${reads[1]} ${prefix}_R2.fastq.gz
+        fastp \\
+            --in1 ${prefix}_R1.fastq.gz \\
+            --in2 ${prefix}_R2.fastq.gz \\
+            $out_fq1 \\
+            $out_fq2 \\
+            --json ${prefix}.fastp.json \\
+            --html ${prefix}.fastp.html \\
+            $adapter_list \\
+            $fail_fastq \\
+            $merge_fastq \\
+            --thread $task.cpus \\
+            --detect_adapter_for_pe \\
+            $args \\
+            2>| >(tee ${prefix}.fastp.log >&2)
+        """
+    }
+
+    stub:
+    def prefix              = task.ext.prefix ?: "${meta.id}"
+    def is_single_output    = task.ext.args?.contains('--interleaved_in') || meta.single_end
+    def touch_reads         = (discard_trimmed_pass) ? "" : (is_single_output) ? "echo '' | gzip > ${prefix}.fastp.fastq.gz" : "echo '' | gzip > ${prefix}_R1.fastp.fastq.gz ; echo '' | gzip > ${prefix}_R2.fastp.fastq.gz"
+    def touch_merged        = (!is_single_output && save_merged) ? "echo '' | gzip >  ${prefix}.merged.fastq.gz" : ""
+    def touch_fail_fastq    = (!save_trimmed_fail) ? "" : meta.single_end ? "echo '' | gzip > ${prefix}.fail.fastq.gz" : "echo '' | gzip > ${prefix}.paired.fail.fastq.gz ; echo '' | gzip > ${prefix}_R1.fail.fastq.gz ; echo '' | gzip > ${prefix}_R2.fail.fastq.gz"
+    """
+    $touch_reads
+    $touch_fail_fastq
+    $touch_merged
+    touch "${prefix}.fastp.json"
+    touch "${prefix}.fastp.html"
+    touch "${prefix}.fastp.log"
+    """
+}

--- a/modules/nf-core/fastp/main.nf
+++ b/modules/nf-core/fastp/main.nf
@@ -4,11 +4,12 @@ process FASTP {
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/52/527b18847a97451091dba07a886b24f17f742a861f9f6c9a6bfb79d4f1f3bf9d/data' :
-        'community.wave.seqera.io/library/fastp:1.0.1--c8b87fe62dcc103c' }"
+        'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/88/889a182b8066804f4799f3808a5813ad601381a8a0e3baa4ab8d73e739b97001/data' :
+        'community.wave.seqera.io/library/fastp:0.24.0--62c97b06e8447690' }"
 
     input:
-    tuple val(meta), path(reads), path(adapter_fasta)
+    tuple val(meta), path(reads)
+    path  adapter_fasta
     val   discard_trimmed_pass
     val   save_trimmed_fail
     val   save_merged
@@ -20,7 +21,7 @@ process FASTP {
     tuple val(meta), path('*.log')            , emit: log
     tuple val(meta), path('*.fail.fastq.gz')  , optional:true, emit: reads_fail
     tuple val(meta), path('*.merged.fastq.gz'), optional:true, emit: reads_merged
-    tuple val("${task.process}"), val('fastp'), eval('fastp --version 2>&1 | sed -e "s/fastp //g"'), emit: versions_fastp, topic: versions
+    path "versions.yml"                       , emit: versions
 
     when:
     task.ext.when == null || task.ext.when
@@ -29,9 +30,9 @@ process FASTP {
     def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
     def adapter_list = adapter_fasta ? "--adapter_fasta ${adapter_fasta}" : ""
-    def fail_fastq = save_trimmed_fail && meta.single_end ? "--failed_out ${prefix}.fail.fastq.gz" : save_trimmed_fail && !meta.single_end ? "--failed_out ${prefix}.paired.fail.fastq.gz --unpaired1 ${prefix}_R1.fail.fastq.gz --unpaired2 ${prefix}_R2.fail.fastq.gz" : ''
-    def out_fq1 = discard_trimmed_pass ?: ( meta.single_end ? "--out1 ${prefix}.fastp.fastq.gz" : "--out1 ${prefix}_R1.fastp.fastq.gz" )
-    def out_fq2 = discard_trimmed_pass ?: "--out2 ${prefix}_R2.fastp.fastq.gz"
+    def fail_fastq = save_trimmed_fail && meta.single_end ? "--failed_out ${prefix}.fail.fastq.gz" : save_trimmed_fail && !meta.single_end ? "--failed_out ${prefix}.paired.fail.fastq.gz --unpaired1 ${prefix}_1.fail.fastq.gz --unpaired2 ${prefix}_2.fail.fastq.gz" : ''
+    def out_fq1 = discard_trimmed_pass ?: ( meta.single_end ? "--out1 ${prefix}.fastp.fastq.gz" : "--out1 ${prefix}_1.fastp.fastq.gz" )
+    def out_fq2 = discard_trimmed_pass ?: "--out2 ${prefix}_2.fastp.fastq.gz"
     // Added soft-links to original fastqs for consistent naming in MultiQC
     // Use single ended for interleaved. Add --interleaved_in in config.
     if ( task.ext.args?.contains('--interleaved_in') ) {
@@ -49,6 +50,11 @@ process FASTP {
             $args \\
             2>| >(tee ${prefix}.fastp.log >&2) \\
         | gzip -c > ${prefix}.fastp.fastq.gz
+
+        cat <<-END_VERSIONS > versions.yml
+        "${task.process}":
+            fastp: \$(fastp --version 2>&1 | sed -e "s/fastp //g")
+        END_VERSIONS
         """
     } else if (meta.single_end) {
         """
@@ -64,15 +70,20 @@ process FASTP {
             $fail_fastq \\
             $args \\
             2>| >(tee ${prefix}.fastp.log >&2)
+
+        cat <<-END_VERSIONS > versions.yml
+        "${task.process}":
+            fastp: \$(fastp --version 2>&1 | sed -e "s/fastp //g")
+        END_VERSIONS
         """
     } else {
         def merge_fastq = save_merged ? "-m --merged_out ${prefix}.merged.fastq.gz" : ''
         """
-        [ ! -f  ${prefix}_R1.fastq.gz ] && ln -sf ${reads[0]} ${prefix}_R1.fastq.gz
-        [ ! -f  ${prefix}_R2.fastq.gz ] && ln -sf ${reads[1]} ${prefix}_R2.fastq.gz
+        [ ! -f  ${prefix}_1.fastq.gz ] && ln -sf ${reads[0]} ${prefix}_1.fastq.gz
+        [ ! -f  ${prefix}_2.fastq.gz ] && ln -sf ${reads[1]} ${prefix}_2.fastq.gz
         fastp \\
-            --in1 ${prefix}_R1.fastq.gz \\
-            --in2 ${prefix}_R2.fastq.gz \\
+            --in1 ${prefix}_1.fastq.gz \\
+            --in2 ${prefix}_2.fastq.gz \\
             $out_fq1 \\
             $out_fq2 \\
             --json ${prefix}.fastp.json \\
@@ -84,15 +95,20 @@ process FASTP {
             --detect_adapter_for_pe \\
             $args \\
             2>| >(tee ${prefix}.fastp.log >&2)
+
+        cat <<-END_VERSIONS > versions.yml
+        "${task.process}":
+            fastp: \$(fastp --version 2>&1 | sed -e "s/fastp //g")
+        END_VERSIONS
         """
     }
 
     stub:
     def prefix              = task.ext.prefix ?: "${meta.id}"
     def is_single_output    = task.ext.args?.contains('--interleaved_in') || meta.single_end
-    def touch_reads         = (discard_trimmed_pass) ? "" : (is_single_output) ? "echo '' | gzip > ${prefix}.fastp.fastq.gz" : "echo '' | gzip > ${prefix}_R1.fastp.fastq.gz ; echo '' | gzip > ${prefix}_R2.fastp.fastq.gz"
+    def touch_reads         = (discard_trimmed_pass) ? "" : (is_single_output) ? "echo '' | gzip > ${prefix}.fastp.fastq.gz" : "echo '' | gzip > ${prefix}_1.fastp.fastq.gz ; echo '' | gzip > ${prefix}_2.fastp.fastq.gz"
     def touch_merged        = (!is_single_output && save_merged) ? "echo '' | gzip >  ${prefix}.merged.fastq.gz" : ""
-    def touch_fail_fastq    = (!save_trimmed_fail) ? "" : meta.single_end ? "echo '' | gzip > ${prefix}.fail.fastq.gz" : "echo '' | gzip > ${prefix}.paired.fail.fastq.gz ; echo '' | gzip > ${prefix}_R1.fail.fastq.gz ; echo '' | gzip > ${prefix}_R2.fail.fastq.gz"
+    def touch_fail_fastq    = (!save_trimmed_fail) ? "" : meta.single_end ? "echo '' | gzip > ${prefix}.fail.fastq.gz" : "echo '' | gzip > ${prefix}.paired.fail.fastq.gz ; echo '' | gzip > ${prefix}_1.fail.fastq.gz ; echo '' | gzip > ${prefix}_2.fail.fastq.gz"
     """
     $touch_reads
     $touch_fail_fastq
@@ -100,5 +116,10 @@ process FASTP {
     touch "${prefix}.fastp.json"
     touch "${prefix}.fastp.html"
     touch "${prefix}.fastp.log"
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        fastp: \$(fastp --version 2>&1 | sed -e "s/fastp //g")
+    END_VERSIONS
     """
 }

--- a/modules/nf-core/fastp/meta.yml
+++ b/modules/nf-core/fastp/meta.yml
@@ -1,0 +1,144 @@
+name: fastp
+description: Perform adapter/quality trimming on sequencing reads
+keywords:
+  - trimming
+  - quality control
+  - fastq
+tools:
+  - fastp:
+      description: |
+        A tool designed to provide fast all-in-one preprocessing for FastQ files. This tool is developed in C++ with multithreading supported to afford high performance.
+      documentation: https://github.com/OpenGene/fastp
+      doi: 10.1093/bioinformatics/bty560
+      licence: ["MIT"]
+      identifier: biotools:fastp
+input:
+  - - meta:
+        type: map
+        description: |
+          Groovy Map containing sample information. Use 'single_end: true' to specify single ended or interleaved FASTQs. Use 'single_end: false' for paired-end reads.
+          e.g. [ id:'test', single_end:false ]
+    - reads:
+        type: file
+        description: |
+          List of input FastQ files of size 1 and 2 for single-end and paired-end data,
+          respectively. If you wish to run interleaved paired-end data,  supply as single-end data
+          but with `--interleaved_in` in your `modules.conf`'s `ext.args` for the module.
+        ontologies: []
+    - adapter_fasta:
+        type: file
+        description: File in FASTA format containing possible adapters to remove.
+        pattern: "*.{fasta,fna,fas,fa}"
+        ontologies: []
+  - discard_trimmed_pass:
+      type: boolean
+      description: |
+        Specify true to not write any reads that pass trimming thresholds.
+        This can be used to use fastp for the output report only.
+  - save_trimmed_fail:
+      type: boolean
+      description: Specify true to save files that failed to pass trimming thresholds
+        ending in `*.fail.fastq.gz`
+  - save_merged:
+      type: boolean
+      description: Specify true to save all merged reads to a file ending in `*.merged.fastq.gz`
+output:
+  reads:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. [ id:'test', single_end:false ]
+      - "*.fastp.fastq.gz":
+          type: file
+          description: The trimmed/modified/unmerged fastq reads
+          pattern: "*fastp.fastq.gz"
+          ontologies:
+            - edam: http://edamontology.org/format_1930 # FASTQ
+            - edam: http://edamontology.org/format_3989 # GZIP format
+  json:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. [ id:'test', single_end:false ]
+      - "*.json":
+          type: file
+          description: Results in JSON format
+          pattern: "*.json"
+          ontologies:
+            - edam: http://edamontology.org/format_3464 # JSON
+  html:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. [ id:'test', single_end:false ]
+      - "*.html":
+          type: file
+          description: Results in HTML format
+          pattern: "*.html"
+          ontologies: []
+  log:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. [ id:'test', single_end:false ]
+      - "*.log":
+          type: file
+          description: fastq log file
+          pattern: "*.log"
+          ontologies: []
+  reads_fail:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. [ id:'test', single_end:false ]
+      - "*.fail.fastq.gz":
+          type: file
+          description: Reads the failed the preprocessing
+          pattern: "*fail.fastq.gz"
+          ontologies:
+            - edam: http://edamontology.org/format_1930 # FASTQ
+            - edam: http://edamontology.org/format_3989 # GZIP format
+  reads_merged:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. [ id:'test', single_end:false ]
+      - "*.merged.fastq.gz":
+          type: file
+          description: Reads that were successfully merged
+          pattern: "*.{merged.fastq.gz}"
+          ontologies: []
+  versions_fastp:
+    - - "${task.process}":
+          type: string
+          description: The name of the process
+      - fastp:
+          type: string
+          description: The name of the tool
+      - 'fastp --version 2>&1 | sed -e "s/fastp //g"':
+          type: eval
+          description: The expression to obtain the version of the tool
+topics:
+  versions:
+    - - "${task.process}":
+          type: string
+          description: The name of the process
+      - fastp:
+          type: string
+          description: The name of the tool
+      - 'fastp --version 2>&1 | sed -e "s/fastp //g"':
+          type: eval
+          description: The expression to obtain the version of the tool
+authors:
+  - "@drpatelh"
+  - "@kevinmenden"
+  - "@eit-maxlcummins"
+maintainers:
+  - "@drpatelh"
+  - "@kevinmenden"

--- a/modules/nf-core/fastp/meta.yml
+++ b/modules/nf-core/fastp/meta.yml
@@ -25,11 +25,11 @@ input:
           respectively. If you wish to run interleaved paired-end data,  supply as single-end data
           but with `--interleaved_in` in your `modules.conf`'s `ext.args` for the module.
         ontologies: []
-    - adapter_fasta:
-        type: file
-        description: File in FASTA format containing possible adapters to remove.
-        pattern: "*.{fasta,fna,fas,fa}"
-        ontologies: []
+  - adapter_fasta:
+      type: file
+      description: File in FASTA format containing possible adapters to remove.
+      pattern: "*.{fasta,fna,fas,fa}"
+      ontologies: []
   - discard_trimmed_pass:
       type: boolean
       description: |
@@ -54,7 +54,6 @@ output:
           description: The trimmed/modified/unmerged fastq reads
           pattern: "*fastp.fastq.gz"
           ontologies:
-            - edam: http://edamontology.org/format_1930 # FASTQ
             - edam: http://edamontology.org/format_3989 # GZIP format
   json:
     - - meta:
@@ -101,7 +100,6 @@ output:
           description: Reads the failed the preprocessing
           pattern: "*fail.fastq.gz"
           ontologies:
-            - edam: http://edamontology.org/format_1930 # FASTQ
             - edam: http://edamontology.org/format_3989 # GZIP format
   reads_merged:
     - - meta:
@@ -114,31 +112,16 @@ output:
           description: Reads that were successfully merged
           pattern: "*.{merged.fastq.gz}"
           ontologies: []
-  versions_fastp:
-    - - "${task.process}":
-          type: string
-          description: The name of the process
-      - fastp:
-          type: string
-          description: The name of the tool
-      - 'fastp --version 2>&1 | sed -e "s/fastp //g"':
-          type: eval
-          description: The expression to obtain the version of the tool
-topics:
   versions:
-    - - "${task.process}":
-          type: string
-          description: The name of the process
-      - fastp:
-          type: string
-          description: The name of the tool
-      - 'fastp --version 2>&1 | sed -e "s/fastp //g"':
-          type: eval
-          description: The expression to obtain the version of the tool
+    - versions.yml:
+        type: file
+        description: File containing software versions
+        pattern: "versions.yml"
+        ontologies:
+          - edam: http://edamontology.org/format_3750 # YAML
 authors:
   - "@drpatelh"
   - "@kevinmenden"
-  - "@eit-maxlcummins"
 maintainers:
   - "@drpatelh"
   - "@kevinmenden"

--- a/modules/nf-core/fastp/tests/main.nf.test
+++ b/modules/nf-core/fastp/tests/main.nf.test
@@ -1,0 +1,661 @@
+nextflow_process {
+
+    name "Test Process FASTP"
+    script "../main.nf"
+    process "FASTP"
+    tag "modules"
+    tag "modules_nfcore"
+    tag "fastp"
+
+    test("test_fastp_single_end") {
+
+        when {
+
+            process {
+                """
+                adapter_fasta        = [] // empty list for no adapter file!
+                discard_trimmed_pass = false
+                save_trimmed_fail    = false
+                save_merged          = false
+
+                input[0] = Channel.of([
+                    [ id:'test', single_end:true ],
+                    [ file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true) ],
+                    adapter_fasta
+                ])
+                input[1] = discard_trimmed_pass
+                input[2] = save_trimmed_fail
+                input[3] = save_merged
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert path(process.out.html.get(0).get(1)).getText().contains("single end (151 cycles)") },
+                { assert path(process.out.log.get(0).get(1)).getText().contains("reads passed filter: 99") },
+                { assert snapshot(
+                    process.out.reads,
+                    process.out.reads_fail,
+                    process.out.reads_merged,
+                    process.out.findAll { key, val -> key.startsWith('versions') }).match()
+                }
+            )
+        }
+    }
+
+    test("test_fastp_paired_end") {
+
+        when {
+
+            process {
+                """
+                adapter_fasta        = []
+                discard_trimmed_pass = false
+                save_trimmed_fail    = false
+                save_merged          = false
+
+                input[0] = Channel.of([
+                    [ id:'test', single_end:false ], // meta map
+                    [
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true),
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_2.fastq.gz', checkIfExists: true)
+                    ],
+                    adapter_fasta
+                ])
+                input[1] = discard_trimmed_pass
+                input[2] = save_trimmed_fail
+                input[3] = save_merged
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert path(process.out.html.get(0).get(1)).getText().contains("The input has little adapter percentage (~0.000000%), probably it's trimmed before.") },
+                { assert path(process.out.log.get(0).get(1)).getText().contains("Q30 bases: 12281(88.3716%)") },
+                { assert snapshot(
+                    process.out.reads,
+                    process.out.reads_fail,
+                    process.out.reads_merged,
+                    process.out.findAll { key, val -> key.startsWith('versions') }).match() }
+            )
+        }
+    }
+
+    test("fastp test_fastp_interleaved") {
+
+        config './nextflow.interleaved.config'
+        when {
+            process {
+                """
+                adapter_fasta        = []
+                discard_trimmed_pass = false
+                save_trimmed_fail    = false
+                save_merged          = false
+
+                input[0] = Channel.of([
+                    [ id:'test', single_end:true ], // meta map
+                    [ file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_interleaved.fastq.gz', checkIfExists: true) ],
+                    adapter_fasta
+                ])
+                input[1] = discard_trimmed_pass
+                input[2] = save_trimmed_fail
+                input[3] = save_merged
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert path(process.out.html.get(0).get(1)).getText().contains("paired end (151 cycles + 151 cycles)") },
+                { assert path(process.out.log.get(0).get(1)).getText().contains("reads passed filter: 162") },
+                { assert process.out.reads_fail == [] },
+                { assert process.out.reads_merged == [] },
+                { assert snapshot(
+                    process.out.reads,
+                    process.out.findAll { key, val -> key.startsWith('versions') }).match() }
+            )
+        }
+    }
+
+    test("test_fastp_single_end_trim_fail") {
+
+        when {
+
+            process {
+                """
+                adapter_fasta        = []
+                discard_trimmed_pass = false
+                save_trimmed_fail    = true
+                save_merged          = false
+
+                input[0] = Channel.of([
+                    [ id:'test', single_end:true ], // meta map
+                    [ file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true) ],
+                    adapter_fasta
+                ])
+                input[1] = discard_trimmed_pass
+                input[2] = save_trimmed_fail
+                input[3] = save_merged
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert path(process.out.html.get(0).get(1)).getText().contains("single end (151 cycles)") },
+                { assert path(process.out.log.get(0).get(1)).getText().contains("reads passed filter: 99") },
+                { assert snapshot(
+                    process.out.reads,
+                    process.out.reads_fail,
+                    process.out.reads_merged,
+                    process.out.findAll { key, val -> key.startsWith('versions') }).match() }
+            )
+        }
+    }
+
+    test("test_fastp_paired_end_trim_fail") {
+
+        config './nextflow.save_failed.config'
+        when {
+            process {
+                """
+                adapter_fasta        = []
+                discard_trimmed_pass = false
+                save_trimmed_fail    = true
+                save_merged          = false
+
+                input[0] = Channel.of([
+                    [ id:'test', single_end:false ], // meta map
+                    [
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true),
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_2.fastq.gz', checkIfExists: true)
+                    ],
+                    adapter_fasta
+                ])
+                input[1] = discard_trimmed_pass
+                input[2] = save_trimmed_fail
+                input[3] = save_merged
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert path(process.out.html.get(0).get(1)).getText().contains("The input has little adapter percentage (~0.000000%), probably it's trimmed before.") },
+                { assert path(process.out.log.get(0).get(1)).getText().contains("reads passed filter: 162") },
+                { assert snapshot(
+                    process.out.reads,
+                    process.out.reads_fail,
+                    process.out.reads_merged,
+                    process.out.findAll { key, val -> key.startsWith('versions') }).match() }
+            )
+        }
+    }
+
+    test("test_fastp_paired_end_merged") {
+
+        when {
+            process {
+                """
+                adapter_fasta        = []
+                discard_trimmed_pass = false
+                save_trimmed_fail    = false
+                save_merged          = true
+
+                input[0] = Channel.of([
+                    [ id:'test', single_end:false ], // meta map
+                    [
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true),
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_2.fastq.gz', checkIfExists: true)
+                    ],
+                    adapter_fasta
+                ])
+                input[1] = discard_trimmed_pass
+                input[2] = save_trimmed_fail
+                input[3] = save_merged
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert path(process.out.html.get(0).get(1)).getText().contains("The input has little adapter percentage (~0.000000%), probably it's trimmed before.") },
+                { assert path(process.out.log.get(0).get(1)).getText().contains("total reads: 75") },
+                { assert snapshot(
+                    process.out.reads,
+                    process.out.reads_fail,
+                    process.out.reads_merged,
+                    process.out.findAll { key, val -> key.startsWith('versions') }).match() },
+            )
+        }
+    }
+
+    test("test_fastp_paired_end_merged_adapterlist") {
+
+        when {
+            process {
+                """
+                adapter_fasta        = file(params.modules_testdata_base_path + 'delete_me/fastp/adapters.fasta', checkIfExists: true)
+                discard_trimmed_pass = false
+                save_trimmed_fail    = false
+                save_merged          = true
+
+                input[0] = Channel.of([
+                    [ id:'test', single_end:false ], // meta map
+                    [
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true),
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_2.fastq.gz', checkIfExists: true)
+                    ],
+                    adapter_fasta
+                ])
+                input[1] = false
+                input[2] = false
+                input[3] = true
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert path(process.out.html.get(0).get(1)).getText().contains("<div id='After_filtering__merged__quality'>") },
+                { assert path(process.out.log.get(0).get(1)).getText().contains("total bases: 13683") },
+                { assert snapshot(
+                    process.out.reads,
+                    process.out.reads_fail,
+                    process.out.reads_merged,
+                    process.out.findAll { key, val -> key.startsWith('versions') }).match() }
+            )
+        }
+    }
+
+    test("test_fastp_single_end_qc_only") {
+
+        when {
+            process {
+                """
+                adapter_fasta        = []
+                discard_trimmed_pass = true
+                save_trimmed_fail    = false
+                save_merged          = false
+
+                input[0] = Channel.of([
+                    [ id:'test', single_end:true ],
+                    [ file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true) ],
+                    adapter_fasta
+                ])
+
+                input[1] = discard_trimmed_pass
+                input[2] = save_trimmed_fail
+                input[3] = save_merged
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert path(process.out.html.get(0).get(1)).getText().contains("single end (151 cycles)") },
+                { assert path(process.out.log.get(0).get(1)).getText().contains("reads passed filter: 99") },
+                { assert snapshot(
+                    process.out.reads,
+                    process.out.reads,
+                    process.out.reads_fail,
+                    process.out.reads_fail,
+                    process.out.reads_merged,
+                    process.out.reads_merged,
+                    process.out.findAll { key, val -> key.startsWith('versions') }).match() }
+            )
+        }
+    }
+
+    test("test_fastp_paired_end_qc_only") {
+
+        when {
+            process {
+                """
+                adapter_fasta        = []
+                discard_trimmed_pass = true
+                save_trimmed_fail    = false
+                save_merged          = false
+
+                input[0] = Channel.of([
+                    [ id:'test', single_end:false ], // meta map
+                    [
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true),
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_2.fastq.gz', checkIfExists: true)
+                    ],
+                    adapter_fasta
+                ])
+                input[1] = discard_trimmed_pass
+                input[2] = save_trimmed_fail
+                input[3] = save_merged
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert path(process.out.html.get(0).get(1)).getText().contains("The input has little adapter percentage (~0.000000%), probably it's trimmed before.") },
+                { assert path(process.out.log.get(0).get(1)).getText().contains("Q30 bases: 12281(88.3716%)") },
+                { assert snapshot(
+                    process.out.reads,
+                    process.out.reads,
+                    process.out.reads_fail,
+                    process.out.reads_fail,
+                    process.out.reads_merged,
+                    process.out.reads_merged,
+                    process.out.findAll { key, val -> key.startsWith('versions') }).match() }
+            )
+        }
+    }
+
+    test("test_fastp_single_end - stub") {
+
+        options "-stub"
+
+        when {
+
+            process {
+                """
+                adapter_fasta        = []
+                discard_trimmed_pass = false
+                save_trimmed_fail    = false
+                save_merged          = false
+
+                input[0] = Channel.of([
+                    [ id:'test', single_end:true ],
+                    [ file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true) ],
+                    adapter_fasta
+                ])
+                input[1] = discard_trimmed_pass
+                input[2] = save_trimmed_fail
+                input[3] = save_merged
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+    }
+
+    test("test_fastp_paired_end - stub") {
+
+        options "-stub"
+
+        when {
+
+            process {
+                """
+                adapter_fasta        = []
+                discard_trimmed_pass = false
+                save_trimmed_fail    = false
+                save_merged          = false
+
+                input[0] = Channel.of([
+                    [ id:'test', single_end:false ], // meta map
+                    [ file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_2.fastq.gz', checkIfExists: true) ],
+                    adapter_fasta
+                ])
+                input[1] = discard_trimmed_pass
+                input[2] = save_trimmed_fail
+                input[3] = save_merged
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+    }
+
+    test("fastp - stub test_fastp_interleaved") {
+
+        options "-stub"
+
+        config './nextflow.interleaved.config'
+        when {
+            process {
+                """
+                adapter_fasta        = []
+                discard_trimmed_pass = false
+                save_trimmed_fail    = false
+                save_merged          = false
+
+                input[0] = Channel.of([
+                    [ id:'test', single_end:true ], // meta map
+                    [ file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_interleaved.fastq.gz', checkIfExists: true) ],
+                    adapter_fasta
+                ])
+                input[1] = discard_trimmed_pass
+                input[2] = save_trimmed_fail
+                input[3] = save_merged
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+    }
+
+    test("test_fastp_single_end_trim_fail - stub") {
+
+        options "-stub"
+
+        when {
+
+            process {
+                """
+                adapter_fasta        = []
+                discard_trimmed_pass = false
+                save_trimmed_fail    = true
+                save_merged          = false
+
+                input[0] = Channel.of([
+                    [ id:'test', single_end:true ], // meta map
+                    [ file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true) ],
+                    adapter_fasta
+                ])
+                input[1] = discard_trimmed_pass
+                input[2] = save_trimmed_fail
+                input[3] = save_merged
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+    }
+
+    test("test_fastp_paired_end_trim_fail - stub") {
+
+        options "-stub"
+
+        config './nextflow.save_failed.config'
+        when {
+            process {
+                """
+                adapter_fasta        = []
+                discard_trimmed_pass = false
+                save_trimmed_fail    = true
+                save_merged          = false
+
+                input[0] = Channel.of([
+                    [ id:'test', single_end:false ], // meta map
+                    [ file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_2.fastq.gz', checkIfExists: true)],
+                    adapter_fasta
+                ])
+                input[1] = discard_trimmed_pass
+                input[2] = save_trimmed_fail
+                input[3] = save_merged
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+    }
+
+    test("test_fastp_paired_end_merged - stub") {
+
+        options "-stub"
+
+        when {
+            process {
+                """
+                adapter_fasta        = []
+                discard_trimmed_pass = false
+                save_trimmed_fail    = false
+                save_merged          = true
+
+                input[0] = Channel.of([
+                    [ id:'test', single_end:false ], // meta map
+                    [ file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_2.fastq.gz', checkIfExists: true) ],
+                    adapter_fasta
+                ])
+                input[1] = discard_trimmed_pass
+                input[2] = save_trimmed_fail
+                input[3] = save_merged
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+    }
+
+    test("test_fastp_paired_end_merged_adapterlist - stub") {
+
+        options "-stub"
+
+        when {
+            process {
+                """
+                adapter_fasta        = file(params.modules_testdata_base_path + 'delete_me/fastp/adapters.fasta', checkIfExists: true)
+                discard_trimmed_pass = false
+                save_trimmed_fail    = false
+                save_merged          = true
+
+                input[0] = Channel.of([
+                    [ id:'test', single_end:false ], // meta map
+                    [
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true),
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_2.fastq.gz', checkIfExists: true)
+                    ],
+                    adapter_fasta
+                ])
+                input[1] = discard_trimmed_pass
+                input[2] = save_trimmed_fail
+                input[3] = save_merged
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+    }
+
+    test("test_fastp_single_end_qc_only - stub") {
+
+        options "-stub"
+
+        when {
+            process {
+                """
+                adapter_fasta        = []
+                discard_trimmed_pass = true
+                save_trimmed_fail    = false
+                save_merged          = false
+
+                input[0] = Channel.of([
+                    [ id:'test', single_end:true ],
+                    [ file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true) ],
+                    adapter_fasta
+                ])
+                input[1] = discard_trimmed_pass
+                input[2] = save_trimmed_fail
+                input[3] = save_merged
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+    }
+
+    test("test_fastp_paired_end_qc_only - stub") {
+
+        options "-stub"
+
+        when {
+            process {
+                """
+                adapter_fasta        = []
+                discard_trimmed_pass = true
+                save_trimmed_fail    = false
+                save_merged          = false
+
+                input[0] = Channel.of([
+                    [ id:'test', single_end:false ], // meta map
+                    [ file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_2.fastq.gz', checkIfExists: true) ],
+                    adapter_fasta
+                ])
+                input[1] = discard_trimmed_pass
+                input[2] = save_trimmed_fail
+                input[3] = save_merged
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+    }
+}

--- a/modules/nf-core/fastp/tests/main.nf.test
+++ b/modules/nf-core/fastp/tests/main.nf.test
@@ -13,19 +13,14 @@ nextflow_process {
 
             process {
                 """
-                adapter_fasta        = [] // empty list for no adapter file!
-                discard_trimmed_pass = false
-                save_trimmed_fail    = false
-                save_merged          = false
-
                 input[0] = Channel.of([
                     [ id:'test', single_end:true ],
-                    [ file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true) ],
-                    adapter_fasta
+                    [ file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true) ]
                 ])
-                input[1] = discard_trimmed_pass
-                input[2] = save_trimmed_fail
-                input[3] = save_merged
+                input[1] = []
+                input[2] = false
+                input[3] = false
+                input[4] = false
                 """
             }
         }
@@ -36,11 +31,11 @@ nextflow_process {
                 { assert path(process.out.html.get(0).get(1)).getText().contains("single end (151 cycles)") },
                 { assert path(process.out.log.get(0).get(1)).getText().contains("reads passed filter: 99") },
                 { assert snapshot(
+                    process.out.json,
                     process.out.reads,
                     process.out.reads_fail,
                     process.out.reads_merged,
-                    process.out.findAll { key, val -> key.startsWith('versions') }).match()
-                }
+                    process.out.versions).match() }
             )
         }
     }
@@ -51,22 +46,20 @@ nextflow_process {
 
             process {
                 """
-                adapter_fasta        = []
-                discard_trimmed_pass = false
-                save_trimmed_fail    = false
-                save_merged          = false
+                adapter_fasta     = []
+                save_trimmed_pass = true
+                save_trimmed_fail = false
+                save_merged       = false
 
                 input[0] = Channel.of([
                     [ id:'test', single_end:false ], // meta map
-                    [
-                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true),
-                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_2.fastq.gz', checkIfExists: true)
-                    ],
-                    adapter_fasta
+                    [ file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_2.fastq.gz', checkIfExists: true) ]
                 ])
-                input[1] = discard_trimmed_pass
-                input[2] = save_trimmed_fail
-                input[3] = save_merged
+                input[1] = []
+                input[2] = false
+                input[3] = false
+                input[4] = false
                 """
             }
         }
@@ -77,10 +70,11 @@ nextflow_process {
                 { assert path(process.out.html.get(0).get(1)).getText().contains("The input has little adapter percentage (~0.000000%), probably it's trimmed before.") },
                 { assert path(process.out.log.get(0).get(1)).getText().contains("Q30 bases: 12281(88.3716%)") },
                 { assert snapshot(
+                    process.out.json,
                     process.out.reads,
                     process.out.reads_fail,
                     process.out.reads_merged,
-                    process.out.findAll { key, val -> key.startsWith('versions') }).match() }
+                    process.out.versions).match() }
             )
         }
     }
@@ -91,19 +85,14 @@ nextflow_process {
         when {
             process {
                 """
-                adapter_fasta        = []
-                discard_trimmed_pass = false
-                save_trimmed_fail    = false
-                save_merged          = false
-
                 input[0] = Channel.of([
                     [ id:'test', single_end:true ], // meta map
-                    [ file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_interleaved.fastq.gz', checkIfExists: true) ],
-                    adapter_fasta
+                    [ file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_interleaved.fastq.gz', checkIfExists: true) ]
                 ])
-                input[1] = discard_trimmed_pass
-                input[2] = save_trimmed_fail
-                input[3] = save_merged
+                input[1] = []
+                input[2] = false
+                input[3] = false
+                input[4] = false
                 """
             }
         }
@@ -117,7 +106,8 @@ nextflow_process {
                 { assert process.out.reads_merged == [] },
                 { assert snapshot(
                     process.out.reads,
-                    process.out.findAll { key, val -> key.startsWith('versions') }).match() }
+                    process.out.json,
+                    process.out.versions).match() }
             )
         }
     }
@@ -128,19 +118,14 @@ nextflow_process {
 
             process {
                 """
-                adapter_fasta        = []
-                discard_trimmed_pass = false
-                save_trimmed_fail    = true
-                save_merged          = false
-
                 input[0] = Channel.of([
                     [ id:'test', single_end:true ], // meta map
-                    [ file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true) ],
-                    adapter_fasta
+                    [ file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true) ]
                 ])
-                input[1] = discard_trimmed_pass
-                input[2] = save_trimmed_fail
-                input[3] = save_merged
+                input[1] = []
+                input[2] = false
+                input[3] = true
+                input[4] = false
                 """
             }
         }
@@ -151,10 +136,11 @@ nextflow_process {
                 { assert path(process.out.html.get(0).get(1)).getText().contains("single end (151 cycles)") },
                 { assert path(process.out.log.get(0).get(1)).getText().contains("reads passed filter: 99") },
                 { assert snapshot(
+                    process.out.json,
                     process.out.reads,
                     process.out.reads_fail,
                     process.out.reads_merged,
-                    process.out.findAll { key, val -> key.startsWith('versions') }).match() }
+                    process.out.versions).match() }
             )
         }
     }
@@ -165,22 +151,15 @@ nextflow_process {
         when {
             process {
                 """
-                adapter_fasta        = []
-                discard_trimmed_pass = false
-                save_trimmed_fail    = true
-                save_merged          = false
-
                 input[0] = Channel.of([
                     [ id:'test', single_end:false ], // meta map
-                    [
-                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true),
-                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_2.fastq.gz', checkIfExists: true)
-                    ],
-                    adapter_fasta
+                    [ file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_2.fastq.gz', checkIfExists: true)]
                 ])
-                input[1] = discard_trimmed_pass
-                input[2] = save_trimmed_fail
-                input[3] = save_merged
+                input[1] = []
+                input[2] = false
+                input[3] = true
+                input[4] = false
                 """
             }
         }
@@ -194,7 +173,8 @@ nextflow_process {
                     process.out.reads,
                     process.out.reads_fail,
                     process.out.reads_merged,
-                    process.out.findAll { key, val -> key.startsWith('versions') }).match() }
+                    process.out.json,
+                    process.out.versions).match() }
             )
         }
     }
@@ -204,22 +184,15 @@ nextflow_process {
         when {
             process {
                 """
-                adapter_fasta        = []
-                discard_trimmed_pass = false
-                save_trimmed_fail    = false
-                save_merged          = true
-
                 input[0] = Channel.of([
                     [ id:'test', single_end:false ], // meta map
-                    [
-                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true),
-                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_2.fastq.gz', checkIfExists: true)
-                    ],
-                    adapter_fasta
+                    [ file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_2.fastq.gz', checkIfExists: true) ]
                 ])
-                input[1] = discard_trimmed_pass
-                input[2] = save_trimmed_fail
-                input[3] = save_merged
+                input[1] = []
+                input[2] = false
+                input[3] = false
+                input[4] = true
                 """
             }
         }
@@ -230,10 +203,11 @@ nextflow_process {
                 { assert path(process.out.html.get(0).get(1)).getText().contains("The input has little adapter percentage (~0.000000%), probably it's trimmed before.") },
                 { assert path(process.out.log.get(0).get(1)).getText().contains("total reads: 75") },
                 { assert snapshot(
+                    process.out.json,
                     process.out.reads,
                     process.out.reads_fail,
                     process.out.reads_merged,
-                    process.out.findAll { key, val -> key.startsWith('versions') }).match() },
+                    process.out.versions).match() },
             )
         }
     }
@@ -243,22 +217,15 @@ nextflow_process {
         when {
             process {
                 """
-                adapter_fasta        = file(params.modules_testdata_base_path + 'delete_me/fastp/adapters.fasta', checkIfExists: true)
-                discard_trimmed_pass = false
-                save_trimmed_fail    = false
-                save_merged          = true
-
                 input[0] = Channel.of([
                     [ id:'test', single_end:false ], // meta map
-                    [
-                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true),
-                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_2.fastq.gz', checkIfExists: true)
-                    ],
-                    adapter_fasta
+                    [ file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_2.fastq.gz', checkIfExists: true) ]
                 ])
-                input[1] = false
+                input[1] =  Channel.of([ file(params.modules_testdata_base_path + 'delete_me/fastp/adapters.fasta', checkIfExists: true) ])
                 input[2] = false
-                input[3] = true
+                input[3] = false
+                input[4] = true
                 """
             }
         }
@@ -269,10 +236,11 @@ nextflow_process {
                 { assert path(process.out.html.get(0).get(1)).getText().contains("<div id='After_filtering__merged__quality'>") },
                 { assert path(process.out.log.get(0).get(1)).getText().contains("total bases: 13683") },
                 { assert snapshot(
+                    process.out.json,
                     process.out.reads,
                     process.out.reads_fail,
                     process.out.reads_merged,
-                    process.out.findAll { key, val -> key.startsWith('versions') }).match() }
+                    process.out.versions).match() }
             )
         }
     }
@@ -282,20 +250,14 @@ nextflow_process {
         when {
             process {
                 """
-                adapter_fasta        = []
-                discard_trimmed_pass = true
-                save_trimmed_fail    = false
-                save_merged          = false
-
                 input[0] = Channel.of([
                     [ id:'test', single_end:true ],
-                    [ file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true) ],
-                    adapter_fasta
+                    [ file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true) ]
                 ])
-
-                input[1] = discard_trimmed_pass
-                input[2] = save_trimmed_fail
-                input[3] = save_merged
+                input[1] = []
+                input[2] = true
+                input[3] = false
+                input[4] = false
                 """
             }
         }
@@ -306,13 +268,14 @@ nextflow_process {
                 { assert path(process.out.html.get(0).get(1)).getText().contains("single end (151 cycles)") },
                 { assert path(process.out.log.get(0).get(1)).getText().contains("reads passed filter: 99") },
                 { assert snapshot(
+                    process.out.json,
                     process.out.reads,
                     process.out.reads,
                     process.out.reads_fail,
                     process.out.reads_fail,
                     process.out.reads_merged,
                     process.out.reads_merged,
-                    process.out.findAll { key, val -> key.startsWith('versions') }).match() }
+                    process.out.versions).match() }
             )
         }
     }
@@ -322,22 +285,15 @@ nextflow_process {
         when {
             process {
                 """
-                adapter_fasta        = []
-                discard_trimmed_pass = true
-                save_trimmed_fail    = false
-                save_merged          = false
-
                 input[0] = Channel.of([
                     [ id:'test', single_end:false ], // meta map
-                    [
-                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true),
-                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_2.fastq.gz', checkIfExists: true)
-                    ],
-                    adapter_fasta
+                    [ file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_2.fastq.gz', checkIfExists: true) ]
                 ])
-                input[1] = discard_trimmed_pass
-                input[2] = save_trimmed_fail
-                input[3] = save_merged
+                input[1] = []
+                input[2] = true
+                input[3] = false
+                input[4] = false
                 """
             }
         }
@@ -348,13 +304,14 @@ nextflow_process {
                 { assert path(process.out.html.get(0).get(1)).getText().contains("The input has little adapter percentage (~0.000000%), probably it's trimmed before.") },
                 { assert path(process.out.log.get(0).get(1)).getText().contains("Q30 bases: 12281(88.3716%)") },
                 { assert snapshot(
+                    process.out.json,
                     process.out.reads,
                     process.out.reads,
                     process.out.reads_fail,
                     process.out.reads_fail,
                     process.out.reads_merged,
                     process.out.reads_merged,
-                    process.out.findAll { key, val -> key.startsWith('versions') }).match() }
+                    process.out.versions).match() }
             )
         }
     }
@@ -367,19 +324,14 @@ nextflow_process {
 
             process {
                 """
-                adapter_fasta        = []
-                discard_trimmed_pass = false
-                save_trimmed_fail    = false
-                save_merged          = false
-
                 input[0] = Channel.of([
                     [ id:'test', single_end:true ],
-                    [ file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true) ],
-                    adapter_fasta
+                    [ file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true) ]
                 ])
-                input[1] = discard_trimmed_pass
-                input[2] = save_trimmed_fail
-                input[3] = save_merged
+                input[1] = []
+                input[2] = false
+                input[3] = false
+                input[4] = false
                 """
             }
         }
@@ -400,20 +352,20 @@ nextflow_process {
 
             process {
                 """
-                adapter_fasta        = []
-                discard_trimmed_pass = false
-                save_trimmed_fail    = false
-                save_merged          = false
+                adapter_fasta     = []
+                save_trimmed_pass = true
+                save_trimmed_fail = false
+                save_merged       = false
 
                 input[0] = Channel.of([
                     [ id:'test', single_end:false ], // meta map
                     [ file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true),
-                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_2.fastq.gz', checkIfExists: true) ],
-                    adapter_fasta
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_2.fastq.gz', checkIfExists: true) ]
                 ])
-                input[1] = discard_trimmed_pass
-                input[2] = save_trimmed_fail
-                input[3] = save_merged
+                input[1] = []
+                input[2] = false
+                input[3] = false
+                input[4] = false
                 """
             }
         }
@@ -434,19 +386,14 @@ nextflow_process {
         when {
             process {
                 """
-                adapter_fasta        = []
-                discard_trimmed_pass = false
-                save_trimmed_fail    = false
-                save_merged          = false
-
                 input[0] = Channel.of([
                     [ id:'test', single_end:true ], // meta map
-                    [ file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_interleaved.fastq.gz', checkIfExists: true) ],
-                    adapter_fasta
+                    [ file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_interleaved.fastq.gz', checkIfExists: true) ]
                 ])
-                input[1] = discard_trimmed_pass
-                input[2] = save_trimmed_fail
-                input[3] = save_merged
+                input[1] = []
+                input[2] = false
+                input[3] = false
+                input[4] = false
                 """
             }
         }
@@ -467,19 +414,14 @@ nextflow_process {
 
             process {
                 """
-                adapter_fasta        = []
-                discard_trimmed_pass = false
-                save_trimmed_fail    = true
-                save_merged          = false
-
                 input[0] = Channel.of([
                     [ id:'test', single_end:true ], // meta map
-                    [ file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true) ],
-                    adapter_fasta
+                    [ file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true) ]
                 ])
-                input[1] = discard_trimmed_pass
-                input[2] = save_trimmed_fail
-                input[3] = save_merged
+                input[1] = []
+                input[2] = false
+                input[3] = true
+                input[4] = false
                 """
             }
         }
@@ -500,20 +442,15 @@ nextflow_process {
         when {
             process {
                 """
-                adapter_fasta        = []
-                discard_trimmed_pass = false
-                save_trimmed_fail    = true
-                save_merged          = false
-
                 input[0] = Channel.of([
                     [ id:'test', single_end:false ], // meta map
                     [ file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true),
-                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_2.fastq.gz', checkIfExists: true)],
-                    adapter_fasta
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_2.fastq.gz', checkIfExists: true)]
                 ])
-                input[1] = discard_trimmed_pass
-                input[2] = save_trimmed_fail
-                input[3] = save_merged
+                input[1] = []
+                input[2] = false
+                input[3] = true
+                input[4] = false
                 """
             }
         }
@@ -533,20 +470,15 @@ nextflow_process {
         when {
             process {
                 """
-                adapter_fasta        = []
-                discard_trimmed_pass = false
-                save_trimmed_fail    = false
-                save_merged          = true
-
                 input[0] = Channel.of([
                     [ id:'test', single_end:false ], // meta map
                     [ file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true),
-                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_2.fastq.gz', checkIfExists: true) ],
-                    adapter_fasta
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_2.fastq.gz', checkIfExists: true) ]
                 ])
-                input[1] = discard_trimmed_pass
-                input[2] = save_trimmed_fail
-                input[3] = save_merged
+                input[1] = []
+                input[2] = false
+                input[3] = false
+                input[4] = true
                 """
             }
         }
@@ -566,22 +498,15 @@ nextflow_process {
         when {
             process {
                 """
-                adapter_fasta        = file(params.modules_testdata_base_path + 'delete_me/fastp/adapters.fasta', checkIfExists: true)
-                discard_trimmed_pass = false
-                save_trimmed_fail    = false
-                save_merged          = true
-
                 input[0] = Channel.of([
                     [ id:'test', single_end:false ], // meta map
-                    [
-                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true),
-                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_2.fastq.gz', checkIfExists: true)
-                    ],
-                    adapter_fasta
+                    [ file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_2.fastq.gz', checkIfExists: true) ]
                 ])
-                input[1] = discard_trimmed_pass
-                input[2] = save_trimmed_fail
-                input[3] = save_merged
+                input[1] =  Channel.of([ file(params.modules_testdata_base_path + 'delete_me/fastp/adapters.fasta', checkIfExists: true) ])
+                input[2] = false
+                input[3] = false
+                input[4] = true
                 """
             }
         }
@@ -601,19 +526,14 @@ nextflow_process {
         when {
             process {
                 """
-                adapter_fasta        = []
-                discard_trimmed_pass = true
-                save_trimmed_fail    = false
-                save_merged          = false
-
                 input[0] = Channel.of([
                     [ id:'test', single_end:true ],
-                    [ file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true) ],
-                    adapter_fasta
+                    [ file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true) ]
                 ])
-                input[1] = discard_trimmed_pass
-                input[2] = save_trimmed_fail
-                input[3] = save_merged
+                input[1] = []
+                input[2] = true
+                input[3] = false
+                input[4] = false
                 """
             }
         }
@@ -633,20 +553,15 @@ nextflow_process {
         when {
             process {
                 """
-                adapter_fasta        = []
-                discard_trimmed_pass = true
-                save_trimmed_fail    = false
-                save_merged          = false
-
                 input[0] = Channel.of([
                     [ id:'test', single_end:false ], // meta map
                     [ file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true),
-                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_2.fastq.gz', checkIfExists: true) ],
-                    adapter_fasta
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_2.fastq.gz', checkIfExists: true) ]
                 ])
-                input[1] = discard_trimmed_pass
-                input[2] = save_trimmed_fail
-                input[3] = save_merged
+                input[1] = []
+                input[2] = true
+                input[3] = false
+                input[4] = false
                 """
             }
         }

--- a/modules/nf-core/fastp/tests/main.nf.test.snap
+++ b/modules/nf-core/fastp/tests/main.nf.test.snap
@@ -1,0 +1,1376 @@
+{
+    "test_fastp_single_end_qc_only - stub": {
+        "content": [
+            {
+                "0": [
+                    
+                ],
+                "1": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": true
+                        },
+                        "test.fastp.json:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "2": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": true
+                        },
+                        "test.fastp.html:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "3": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": true
+                        },
+                        "test.fastp.log:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "4": [
+                    
+                ],
+                "5": [
+                    
+                ],
+                "6": [
+                    [
+                        "FASTP",
+                        "fastp",
+                        "1.0.1"
+                    ]
+                ],
+                "html": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": true
+                        },
+                        "test.fastp.html:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "json": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": true
+                        },
+                        "test.fastp.json:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "log": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": true
+                        },
+                        "test.fastp.log:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "reads": [
+                    
+                ],
+                "reads_fail": [
+                    
+                ],
+                "reads_merged": [
+                    
+                ],
+                "versions_fastp": [
+                    [
+                        "FASTP",
+                        "fastp",
+                        "1.0.1"
+                    ]
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.2"
+        },
+        "timestamp": "2026-01-22T13:00:52.14535813"
+    },
+    "test_fastp_paired_end": {
+        "content": [
+            [
+                [
+                    {
+                        "id": "test",
+                        "single_end": false
+                    },
+                    [
+                        "test_R1.fastp.fastq.gz:md5,67b2bbae47f073e05a97a9c2edce23c7",
+                        "test_R2.fastp.fastq.gz:md5,25cbdca08e2083dbd4f0502de6b62f39"
+                    ]
+                ]
+            ],
+            [
+                
+            ],
+            [
+                
+            ],
+            {
+                "versions_fastp": [
+                    [
+                        "FASTP",
+                        "fastp",
+                        "1.0.1"
+                    ]
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.2"
+        },
+        "timestamp": "2026-01-23T09:46:26.421773402"
+    },
+    "test_fastp_paired_end_merged_adapterlist": {
+        "content": [
+            [
+                [
+                    {
+                        "id": "test",
+                        "single_end": false
+                    },
+                    [
+                        "test_R1.fastp.fastq.gz:md5,54b726a55e992a869fd3fa778afe1672",
+                        "test_R2.fastp.fastq.gz:md5,29d3b33b869f7b63417b8ff07bb128ba"
+                    ]
+                ]
+            ],
+            [
+                
+            ],
+            [
+                [
+                    {
+                        "id": "test",
+                        "single_end": false
+                    },
+                    "test.merged.fastq.gz:md5,c873bb1ab3fa859dcc47306465e749d5"
+                ]
+            ],
+            {
+                "versions_fastp": [
+                    [
+                        "FASTP",
+                        "fastp",
+                        "1.0.1"
+                    ]
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.2"
+        },
+        "timestamp": "2026-01-23T09:46:59.832295907"
+    },
+    "test_fastp_single_end_qc_only": {
+        "content": [
+            [
+                
+            ],
+            [
+                
+            ],
+            [
+                
+            ],
+            [
+                
+            ],
+            [
+                
+            ],
+            [
+                
+            ],
+            {
+                "versions_fastp": [
+                    [
+                        "FASTP",
+                        "fastp",
+                        "1.0.1"
+                    ]
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.2"
+        },
+        "timestamp": "2026-01-23T09:47:06.486959565"
+    },
+    "test_fastp_paired_end_trim_fail": {
+        "content": [
+            [
+                [
+                    {
+                        "id": "test",
+                        "single_end": false
+                    },
+                    [
+                        "test_R1.fastp.fastq.gz:md5,6ff32a64c5188b9a9192be1398c262c7",
+                        "test_R2.fastp.fastq.gz:md5,db0cb7c9977e94ac2b4b446ebd017a8a"
+                    ]
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "test",
+                        "single_end": false
+                    },
+                    [
+                        "test.paired.fail.fastq.gz:md5,409b687c734cedd7a1fec14d316e1366",
+                        "test_R1.fail.fastq.gz:md5,4f273cf3159c13f79e8ffae12f5661f6",
+                        "test_R2.fail.fastq.gz:md5,f97b9edefb5649aab661fbc9e71fc995"
+                    ]
+                ]
+            ],
+            [
+                
+            ],
+            {
+                "versions_fastp": [
+                    [
+                        "FASTP",
+                        "fastp",
+                        "1.0.1"
+                    ]
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.2"
+        },
+        "timestamp": "2026-01-23T09:46:46.736511024"
+    },
+    "fastp - stub test_fastp_interleaved": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": true
+                        },
+                        "test.fastp.fastq.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                    ]
+                ],
+                "1": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": true
+                        },
+                        "test.fastp.json:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "2": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": true
+                        },
+                        "test.fastp.html:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "3": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": true
+                        },
+                        "test.fastp.log:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "4": [
+                    
+                ],
+                "5": [
+                    
+                ],
+                "6": [
+                    [
+                        "FASTP",
+                        "fastp",
+                        "1.0.1"
+                    ]
+                ],
+                "html": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": true
+                        },
+                        "test.fastp.html:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "json": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": true
+                        },
+                        "test.fastp.json:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "log": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": true
+                        },
+                        "test.fastp.log:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "reads": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": true
+                        },
+                        "test.fastp.fastq.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                    ]
+                ],
+                "reads_fail": [
+                    
+                ],
+                "reads_merged": [
+                    
+                ],
+                "versions_fastp": [
+                    [
+                        "FASTP",
+                        "fastp",
+                        "1.0.1"
+                    ]
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.2"
+        },
+        "timestamp": "2026-01-22T13:00:16.097071654"
+    },
+    "test_fastp_single_end - stub": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": true
+                        },
+                        "test.fastp.fastq.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                    ]
+                ],
+                "1": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": true
+                        },
+                        "test.fastp.json:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "2": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": true
+                        },
+                        "test.fastp.html:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "3": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": true
+                        },
+                        "test.fastp.log:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "4": [
+                    
+                ],
+                "5": [
+                    
+                ],
+                "6": [
+                    [
+                        "FASTP",
+                        "fastp",
+                        "1.0.1"
+                    ]
+                ],
+                "html": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": true
+                        },
+                        "test.fastp.html:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "json": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": true
+                        },
+                        "test.fastp.json:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "log": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": true
+                        },
+                        "test.fastp.log:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "reads": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": true
+                        },
+                        "test.fastp.fastq.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                    ]
+                ],
+                "reads_fail": [
+                    
+                ],
+                "reads_merged": [
+                    
+                ],
+                "versions_fastp": [
+                    [
+                        "FASTP",
+                        "fastp",
+                        "1.0.1"
+                    ]
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.2"
+        },
+        "timestamp": "2026-01-22T13:00:03.317192706"
+    },
+    "test_fastp_paired_end_merged_adapterlist - stub": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        [
+                            "test_R1.fastp.fastq.gz:md5,68b329da9893e34099c7d8ad5cb9c940",
+                            "test_R2.fastp.fastq.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                        ]
+                    ]
+                ],
+                "1": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.fastp.json:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "2": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.fastp.html:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "3": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.fastp.log:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "4": [
+                    
+                ],
+                "5": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.merged.fastq.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                    ]
+                ],
+                "6": [
+                    [
+                        "FASTP",
+                        "fastp",
+                        "1.0.1"
+                    ]
+                ],
+                "html": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.fastp.html:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "json": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.fastp.json:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "log": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.fastp.log:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "reads": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        [
+                            "test_R1.fastp.fastq.gz:md5,68b329da9893e34099c7d8ad5cb9c940",
+                            "test_R2.fastp.fastq.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                        ]
+                    ]
+                ],
+                "reads_fail": [
+                    
+                ],
+                "reads_merged": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.merged.fastq.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                    ]
+                ],
+                "versions_fastp": [
+                    [
+                        "FASTP",
+                        "fastp",
+                        "1.0.1"
+                    ]
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.2"
+        },
+        "timestamp": "2026-01-22T13:00:44.851708205"
+    },
+    "test_fastp_paired_end_merged - stub": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        [
+                            "test_R1.fastp.fastq.gz:md5,68b329da9893e34099c7d8ad5cb9c940",
+                            "test_R2.fastp.fastq.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                        ]
+                    ]
+                ],
+                "1": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.fastp.json:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "2": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.fastp.html:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "3": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.fastp.log:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "4": [
+                    
+                ],
+                "5": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.merged.fastq.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                    ]
+                ],
+                "6": [
+                    [
+                        "FASTP",
+                        "fastp",
+                        "1.0.1"
+                    ]
+                ],
+                "html": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.fastp.html:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "json": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.fastp.json:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "log": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.fastp.log:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "reads": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        [
+                            "test_R1.fastp.fastq.gz:md5,68b329da9893e34099c7d8ad5cb9c940",
+                            "test_R2.fastp.fastq.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                        ]
+                    ]
+                ],
+                "reads_fail": [
+                    
+                ],
+                "reads_merged": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.merged.fastq.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                    ]
+                ],
+                "versions_fastp": [
+                    [
+                        "FASTP",
+                        "fastp",
+                        "1.0.1"
+                    ]
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.2"
+        },
+        "timestamp": "2026-01-22T13:00:37.581047713"
+    },
+    "test_fastp_paired_end_merged": {
+        "content": [
+            [
+                [
+                    {
+                        "id": "test",
+                        "single_end": false
+                    },
+                    [
+                        "test_R1.fastp.fastq.gz:md5,54b726a55e992a869fd3fa778afe1672",
+                        "test_R2.fastp.fastq.gz:md5,29d3b33b869f7b63417b8ff07bb128ba"
+                    ]
+                ]
+            ],
+            [
+                
+            ],
+            [
+                [
+                    {
+                        "id": "test",
+                        "single_end": false
+                    },
+                    "test.merged.fastq.gz:md5,c873bb1ab3fa859dcc47306465e749d5"
+                ]
+            ],
+            {
+                "versions_fastp": [
+                    [
+                        "FASTP",
+                        "fastp",
+                        "1.0.1"
+                    ]
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.2"
+        },
+        "timestamp": "2026-01-23T09:46:53.190202914"
+    },
+    "test_fastp_paired_end - stub": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        [
+                            "test_R1.fastp.fastq.gz:md5,68b329da9893e34099c7d8ad5cb9c940",
+                            "test_R2.fastp.fastq.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                        ]
+                    ]
+                ],
+                "1": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.fastp.json:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "2": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.fastp.html:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "3": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.fastp.log:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "4": [
+                    
+                ],
+                "5": [
+                    
+                ],
+                "6": [
+                    [
+                        "FASTP",
+                        "fastp",
+                        "1.0.1"
+                    ]
+                ],
+                "html": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.fastp.html:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "json": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.fastp.json:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "log": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.fastp.log:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "reads": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        [
+                            "test_R1.fastp.fastq.gz:md5,68b329da9893e34099c7d8ad5cb9c940",
+                            "test_R2.fastp.fastq.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                        ]
+                    ]
+                ],
+                "reads_fail": [
+                    
+                ],
+                "reads_merged": [
+                    
+                ],
+                "versions_fastp": [
+                    [
+                        "FASTP",
+                        "fastp",
+                        "1.0.1"
+                    ]
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.2"
+        },
+        "timestamp": "2026-01-22T13:00:09.585957282"
+    },
+    "test_fastp_single_end": {
+        "content": [
+            [
+                [
+                    {
+                        "id": "test",
+                        "single_end": true
+                    },
+                    "test.fastp.fastq.gz:md5,67b2bbae47f073e05a97a9c2edce23c7"
+                ]
+            ],
+            [
+                
+            ],
+            [
+                
+            ],
+            {
+                "versions_fastp": [
+                    [
+                        "FASTP",
+                        "fastp",
+                        "1.0.1"
+                    ]
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.2"
+        },
+        "timestamp": "2026-01-23T09:46:19.624824985"
+    },
+    "test_fastp_single_end_trim_fail - stub": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": true
+                        },
+                        "test.fastp.fastq.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                    ]
+                ],
+                "1": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": true
+                        },
+                        "test.fastp.json:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "2": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": true
+                        },
+                        "test.fastp.html:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "3": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": true
+                        },
+                        "test.fastp.log:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "4": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": true
+                        },
+                        "test.fail.fastq.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                    ]
+                ],
+                "5": [
+                    
+                ],
+                "6": [
+                    [
+                        "FASTP",
+                        "fastp",
+                        "1.0.1"
+                    ]
+                ],
+                "html": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": true
+                        },
+                        "test.fastp.html:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "json": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": true
+                        },
+                        "test.fastp.json:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "log": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": true
+                        },
+                        "test.fastp.log:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "reads": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": true
+                        },
+                        "test.fastp.fastq.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                    ]
+                ],
+                "reads_fail": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": true
+                        },
+                        "test.fail.fastq.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                    ]
+                ],
+                "reads_merged": [
+                    
+                ],
+                "versions_fastp": [
+                    [
+                        "FASTP",
+                        "fastp",
+                        "1.0.1"
+                    ]
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.2"
+        },
+        "timestamp": "2026-01-22T13:00:22.800659826"
+    },
+    "test_fastp_paired_end_trim_fail - stub": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        [
+                            "test_R1.fastp.fastq.gz:md5,68b329da9893e34099c7d8ad5cb9c940",
+                            "test_R2.fastp.fastq.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                        ]
+                    ]
+                ],
+                "1": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.fastp.json:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "2": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.fastp.html:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "3": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.fastp.log:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "4": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        [
+                            "test.paired.fail.fastq.gz:md5,68b329da9893e34099c7d8ad5cb9c940",
+                            "test_R1.fail.fastq.gz:md5,68b329da9893e34099c7d8ad5cb9c940",
+                            "test_R2.fail.fastq.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                        ]
+                    ]
+                ],
+                "5": [
+                    
+                ],
+                "6": [
+                    [
+                        "FASTP",
+                        "fastp",
+                        "1.0.1"
+                    ]
+                ],
+                "html": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.fastp.html:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "json": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.fastp.json:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "log": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.fastp.log:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "reads": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        [
+                            "test_R1.fastp.fastq.gz:md5,68b329da9893e34099c7d8ad5cb9c940",
+                            "test_R2.fastp.fastq.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                        ]
+                    ]
+                ],
+                "reads_fail": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        [
+                            "test.paired.fail.fastq.gz:md5,68b329da9893e34099c7d8ad5cb9c940",
+                            "test_R1.fail.fastq.gz:md5,68b329da9893e34099c7d8ad5cb9c940",
+                            "test_R2.fail.fastq.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                        ]
+                    ]
+                ],
+                "reads_merged": [
+                    
+                ],
+                "versions_fastp": [
+                    [
+                        "FASTP",
+                        "fastp",
+                        "1.0.1"
+                    ]
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.2"
+        },
+        "timestamp": "2026-01-22T13:00:30.271734068"
+    },
+    "fastp test_fastp_interleaved": {
+        "content": [
+            [
+                [
+                    {
+                        "id": "test",
+                        "single_end": true
+                    },
+                    "test.fastp.fastq.gz:md5,217d62dc13a23e92513a1bd8e1bcea39"
+                ]
+            ],
+            {
+                "versions_fastp": [
+                    [
+                        "FASTP",
+                        "fastp",
+                        "1.0.1"
+                    ]
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.2"
+        },
+        "timestamp": "2026-01-23T09:46:33.4628687"
+    },
+    "test_fastp_single_end_trim_fail": {
+        "content": [
+            [
+                [
+                    {
+                        "id": "test",
+                        "single_end": true
+                    },
+                    "test.fastp.fastq.gz:md5,67b2bbae47f073e05a97a9c2edce23c7"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "test",
+                        "single_end": true
+                    },
+                    "test.fail.fastq.gz:md5,3e4aaadb66a5b8fc9b881bf39c227abd"
+                ]
+            ],
+            [
+                
+            ],
+            {
+                "versions_fastp": [
+                    [
+                        "FASTP",
+                        "fastp",
+                        "1.0.1"
+                    ]
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.2"
+        },
+        "timestamp": "2026-01-23T09:46:39.895973372"
+    },
+    "test_fastp_paired_end_qc_only": {
+        "content": [
+            [
+                
+            ],
+            [
+                
+            ],
+            [
+                
+            ],
+            [
+                
+            ],
+            [
+                
+            ],
+            [
+                
+            ],
+            {
+                "versions_fastp": [
+                    [
+                        "FASTP",
+                        "fastp",
+                        "1.0.1"
+                    ]
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.2"
+        },
+        "timestamp": "2026-01-23T09:47:13.015833707"
+    },
+    "test_fastp_paired_end_qc_only - stub": {
+        "content": [
+            {
+                "0": [
+                    
+                ],
+                "1": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.fastp.json:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "2": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.fastp.html:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "3": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.fastp.log:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "4": [
+                    
+                ],
+                "5": [
+                    
+                ],
+                "6": [
+                    [
+                        "FASTP",
+                        "fastp",
+                        "1.0.1"
+                    ]
+                ],
+                "html": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.fastp.html:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "json": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.fastp.json:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "log": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.fastp.log:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "reads": [
+                    
+                ],
+                "reads_fail": [
+                    
+                ],
+                "reads_merged": [
+                    
+                ],
+                "versions_fastp": [
+                    [
+                        "FASTP",
+                        "fastp",
+                        "1.0.1"
+                    ]
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.2"
+        },
+        "timestamp": "2026-01-22T13:00:59.670106791"
+    }
+}

--- a/modules/nf-core/fastp/tests/main.nf.test.snap
+++ b/modules/nf-core/fastp/tests/main.nf.test.snap
@@ -39,11 +39,7 @@
                     
                 ],
                 "6": [
-                    [
-                        "FASTP",
-                        "fastp",
-                        "1.0.1"
-                    ]
+                    "versions.yml:md5,3799377c4173131ba9392346e1c40bb9"
                 ],
                 "html": [
                     [
@@ -81,20 +77,16 @@
                 "reads_merged": [
                     
                 ],
-                "versions_fastp": [
-                    [
-                        "FASTP",
-                        "fastp",
-                        "1.0.1"
-                    ]
+                "versions": [
+                    "versions.yml:md5,3799377c4173131ba9392346e1c40bb9"
                 ]
             }
         ],
         "meta": {
-            "nf-test": "0.9.3",
-            "nextflow": "25.10.2"
+            "nf-test": "0.9.2",
+            "nextflow": "24.10.5"
         },
-        "timestamp": "2026-01-22T13:00:52.14535813"
+        "timestamp": "2025-03-31T13:40:51.8619133"
     },
     "test_fastp_paired_end": {
         "content": [
@@ -104,9 +96,18 @@
                         "id": "test",
                         "single_end": false
                     },
+                    "test.fastp.json:md5,7cf3bff1922b512bcca58439eb2d3679"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "test",
+                        "single_end": false
+                    },
                     [
-                        "test_R1.fastp.fastq.gz:md5,67b2bbae47f073e05a97a9c2edce23c7",
-                        "test_R2.fastp.fastq.gz:md5,25cbdca08e2083dbd4f0502de6b62f39"
+                        "test_1.fastp.fastq.gz:md5,67b2bbae47f073e05a97a9c2edce23c7",
+                        "test_2.fastp.fastq.gz:md5,25cbdca08e2083dbd4f0502de6b62f39"
                     ]
                 ]
             ],
@@ -116,21 +117,15 @@
             [
                 
             ],
-            {
-                "versions_fastp": [
-                    [
-                        "FASTP",
-                        "fastp",
-                        "1.0.1"
-                    ]
-                ]
-            }
+            [
+                "versions.yml:md5,3799377c4173131ba9392346e1c40bb9"
+            ]
         ],
         "meta": {
-            "nf-test": "0.9.3",
-            "nextflow": "25.10.2"
+            "nf-test": "0.9.2",
+            "nextflow": "24.10.5"
         },
-        "timestamp": "2026-01-23T09:46:26.421773402"
+        "timestamp": "2025-03-31T13:39:15.121411815"
     },
     "test_fastp_paired_end_merged_adapterlist": {
         "content": [
@@ -140,9 +135,18 @@
                         "id": "test",
                         "single_end": false
                     },
+                    "test.fastp.json:md5,533983f8c11cc3f2ccdcea01531f68ae"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "test",
+                        "single_end": false
+                    },
                     [
-                        "test_R1.fastp.fastq.gz:md5,54b726a55e992a869fd3fa778afe1672",
-                        "test_R2.fastp.fastq.gz:md5,29d3b33b869f7b63417b8ff07bb128ba"
+                        "test_1.fastp.fastq.gz:md5,54b726a55e992a869fd3fa778afe1672",
+                        "test_2.fastp.fastq.gz:md5,29d3b33b869f7b63417b8ff07bb128ba"
                     ]
                 ]
             ],
@@ -158,57 +162,54 @@
                     "test.merged.fastq.gz:md5,c873bb1ab3fa859dcc47306465e749d5"
                 ]
             ],
-            {
-                "versions_fastp": [
-                    [
-                        "FASTP",
-                        "fastp",
-                        "1.0.1"
-                    ]
-                ]
-            }
+            [
+                "versions.yml:md5,3799377c4173131ba9392346e1c40bb9"
+            ]
         ],
         "meta": {
-            "nf-test": "0.9.3",
-            "nextflow": "25.10.2"
+            "nf-test": "0.9.2",
+            "nextflow": "24.10.5"
         },
-        "timestamp": "2026-01-23T09:46:59.832295907"
+        "timestamp": "2025-03-31T13:39:51.561598206"
     },
     "test_fastp_single_end_qc_only": {
         "content": [
             [
-                
-            ],
-            [
-                
-            ],
-            [
-                
-            ],
-            [
-                
-            ],
-            [
-                
-            ],
-            [
-                
-            ],
-            {
-                "versions_fastp": [
-                    [
-                        "FASTP",
-                        "fastp",
-                        "1.0.1"
-                    ]
+                [
+                    {
+                        "id": "test",
+                        "single_end": true
+                    },
+                    "test.fastp.json:md5,93f407199ee8b94c023c291bddfc4dce"
                 ]
-            }
+            ],
+            [
+                
+            ],
+            [
+                
+            ],
+            [
+                
+            ],
+            [
+                
+            ],
+            [
+                
+            ],
+            [
+                
+            ],
+            [
+                "versions.yml:md5,3799377c4173131ba9392346e1c40bb9"
+            ]
         ],
         "meta": {
-            "nf-test": "0.9.3",
-            "nextflow": "25.10.2"
+            "nf-test": "0.9.2",
+            "nextflow": "24.10.5"
         },
-        "timestamp": "2026-01-23T09:47:06.486959565"
+        "timestamp": "2025-03-31T13:39:56.392912049"
     },
     "test_fastp_paired_end_trim_fail": {
         "content": [
@@ -219,8 +220,8 @@
                         "single_end": false
                     },
                     [
-                        "test_R1.fastp.fastq.gz:md5,6ff32a64c5188b9a9192be1398c262c7",
-                        "test_R2.fastp.fastq.gz:md5,db0cb7c9977e94ac2b4b446ebd017a8a"
+                        "test_1.fastp.fastq.gz:md5,6ff32a64c5188b9a9192be1398c262c7",
+                        "test_2.fastp.fastq.gz:md5,db0cb7c9977e94ac2b4b446ebd017a8a"
                     ]
                 ]
             ],
@@ -232,29 +233,32 @@
                     },
                     [
                         "test.paired.fail.fastq.gz:md5,409b687c734cedd7a1fec14d316e1366",
-                        "test_R1.fail.fastq.gz:md5,4f273cf3159c13f79e8ffae12f5661f6",
-                        "test_R2.fail.fastq.gz:md5,f97b9edefb5649aab661fbc9e71fc995"
+                        "test_1.fail.fastq.gz:md5,4f273cf3159c13f79e8ffae12f5661f6",
+                        "test_2.fail.fastq.gz:md5,f97b9edefb5649aab661fbc9e71fc995"
                     ]
                 ]
             ],
             [
                 
             ],
-            {
-                "versions_fastp": [
-                    [
-                        "FASTP",
-                        "fastp",
-                        "1.0.1"
-                    ]
+            [
+                [
+                    {
+                        "id": "test",
+                        "single_end": false
+                    },
+                    "test.fastp.json:md5,5009a892192f2084c2af69c153d88d6c"
                 ]
-            }
+            ],
+            [
+                "versions.yml:md5,3799377c4173131ba9392346e1c40bb9"
+            ]
         ],
         "meta": {
-            "nf-test": "0.9.3",
-            "nextflow": "25.10.2"
+            "nf-test": "0.9.2",
+            "nextflow": "24.10.5"
         },
-        "timestamp": "2026-01-23T09:46:46.736511024"
+        "timestamp": "2025-03-31T13:39:38.690242568"
     },
     "fastp - stub test_fastp_interleaved": {
         "content": [
@@ -302,11 +306,7 @@
                     
                 ],
                 "6": [
-                    [
-                        "FASTP",
-                        "fastp",
-                        "1.0.1"
-                    ]
+                    "versions.yml:md5,3799377c4173131ba9392346e1c40bb9"
                 ],
                 "html": [
                     [
@@ -350,20 +350,16 @@
                 "reads_merged": [
                     
                 ],
-                "versions_fastp": [
-                    [
-                        "FASTP",
-                        "fastp",
-                        "1.0.1"
-                    ]
+                "versions": [
+                    "versions.yml:md5,3799377c4173131ba9392346e1c40bb9"
                 ]
             }
         ],
         "meta": {
-            "nf-test": "0.9.3",
-            "nextflow": "25.10.2"
+            "nf-test": "0.9.2",
+            "nextflow": "24.10.5"
         },
-        "timestamp": "2026-01-22T13:00:16.097071654"
+        "timestamp": "2025-03-31T13:40:23.678200076"
     },
     "test_fastp_single_end - stub": {
         "content": [
@@ -411,11 +407,7 @@
                     
                 ],
                 "6": [
-                    [
-                        "FASTP",
-                        "fastp",
-                        "1.0.1"
-                    ]
+                    "versions.yml:md5,3799377c4173131ba9392346e1c40bb9"
                 ],
                 "html": [
                     [
@@ -459,20 +451,16 @@
                 "reads_merged": [
                     
                 ],
-                "versions_fastp": [
-                    [
-                        "FASTP",
-                        "fastp",
-                        "1.0.1"
-                    ]
+                "versions": [
+                    "versions.yml:md5,3799377c4173131ba9392346e1c40bb9"
                 ]
             }
         ],
         "meta": {
-            "nf-test": "0.9.3",
-            "nextflow": "25.10.2"
+            "nf-test": "0.9.2",
+            "nextflow": "24.10.5"
         },
-        "timestamp": "2026-01-22T13:00:03.317192706"
+        "timestamp": "2025-03-31T13:40:08.756547678"
     },
     "test_fastp_paired_end_merged_adapterlist - stub": {
         "content": [
@@ -484,8 +472,8 @@
                             "single_end": false
                         },
                         [
-                            "test_R1.fastp.fastq.gz:md5,68b329da9893e34099c7d8ad5cb9c940",
-                            "test_R2.fastp.fastq.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                            "test_1.fastp.fastq.gz:md5,68b329da9893e34099c7d8ad5cb9c940",
+                            "test_2.fastp.fastq.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
                         ]
                     ]
                 ],
@@ -529,11 +517,7 @@
                     ]
                 ],
                 "6": [
-                    [
-                        "FASTP",
-                        "fastp",
-                        "1.0.1"
-                    ]
+                    "versions.yml:md5,3799377c4173131ba9392346e1c40bb9"
                 ],
                 "html": [
                     [
@@ -569,8 +553,8 @@
                             "single_end": false
                         },
                         [
-                            "test_R1.fastp.fastq.gz:md5,68b329da9893e34099c7d8ad5cb9c940",
-                            "test_R2.fastp.fastq.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                            "test_1.fastp.fastq.gz:md5,68b329da9893e34099c7d8ad5cb9c940",
+                            "test_2.fastp.fastq.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
                         ]
                     ]
                 ],
@@ -586,20 +570,16 @@
                         "test.merged.fastq.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
                     ]
                 ],
-                "versions_fastp": [
-                    [
-                        "FASTP",
-                        "fastp",
-                        "1.0.1"
-                    ]
+                "versions": [
+                    "versions.yml:md5,3799377c4173131ba9392346e1c40bb9"
                 ]
             }
         ],
         "meta": {
-            "nf-test": "0.9.3",
-            "nextflow": "25.10.2"
+            "nf-test": "0.9.2",
+            "nextflow": "24.10.5"
         },
-        "timestamp": "2026-01-22T13:00:44.851708205"
+        "timestamp": "2025-03-31T13:40:47.596331823"
     },
     "test_fastp_paired_end_merged - stub": {
         "content": [
@@ -611,8 +591,8 @@
                             "single_end": false
                         },
                         [
-                            "test_R1.fastp.fastq.gz:md5,68b329da9893e34099c7d8ad5cb9c940",
-                            "test_R2.fastp.fastq.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                            "test_1.fastp.fastq.gz:md5,68b329da9893e34099c7d8ad5cb9c940",
+                            "test_2.fastp.fastq.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
                         ]
                     ]
                 ],
@@ -656,11 +636,7 @@
                     ]
                 ],
                 "6": [
-                    [
-                        "FASTP",
-                        "fastp",
-                        "1.0.1"
-                    ]
+                    "versions.yml:md5,3799377c4173131ba9392346e1c40bb9"
                 ],
                 "html": [
                     [
@@ -696,8 +672,8 @@
                             "single_end": false
                         },
                         [
-                            "test_R1.fastp.fastq.gz:md5,68b329da9893e34099c7d8ad5cb9c940",
-                            "test_R2.fastp.fastq.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                            "test_1.fastp.fastq.gz:md5,68b329da9893e34099c7d8ad5cb9c940",
+                            "test_2.fastp.fastq.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
                         ]
                     ]
                 ],
@@ -713,20 +689,16 @@
                         "test.merged.fastq.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
                     ]
                 ],
-                "versions_fastp": [
-                    [
-                        "FASTP",
-                        "fastp",
-                        "1.0.1"
-                    ]
+                "versions": [
+                    "versions.yml:md5,3799377c4173131ba9392346e1c40bb9"
                 ]
             }
         ],
         "meta": {
-            "nf-test": "0.9.3",
-            "nextflow": "25.10.2"
+            "nf-test": "0.9.2",
+            "nextflow": "24.10.5"
         },
-        "timestamp": "2026-01-22T13:00:37.581047713"
+        "timestamp": "2025-03-31T13:40:39.962303534"
     },
     "test_fastp_paired_end_merged": {
         "content": [
@@ -736,9 +708,18 @@
                         "id": "test",
                         "single_end": false
                     },
+                    "test.fastp.json:md5,8f99097bfa04b629891105b8af9c429f"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "test",
+                        "single_end": false
+                    },
                     [
-                        "test_R1.fastp.fastq.gz:md5,54b726a55e992a869fd3fa778afe1672",
-                        "test_R2.fastp.fastq.gz:md5,29d3b33b869f7b63417b8ff07bb128ba"
+                        "test_1.fastp.fastq.gz:md5,54b726a55e992a869fd3fa778afe1672",
+                        "test_2.fastp.fastq.gz:md5,29d3b33b869f7b63417b8ff07bb128ba"
                     ]
                 ]
             ],
@@ -754,21 +735,15 @@
                     "test.merged.fastq.gz:md5,c873bb1ab3fa859dcc47306465e749d5"
                 ]
             ],
-            {
-                "versions_fastp": [
-                    [
-                        "FASTP",
-                        "fastp",
-                        "1.0.1"
-                    ]
-                ]
-            }
+            [
+                "versions.yml:md5,3799377c4173131ba9392346e1c40bb9"
+            ]
         ],
         "meta": {
-            "nf-test": "0.9.3",
-            "nextflow": "25.10.2"
+            "nf-test": "0.9.2",
+            "nextflow": "24.10.5"
         },
-        "timestamp": "2026-01-23T09:46:53.190202914"
+        "timestamp": "2025-03-31T13:39:46.300238743"
     },
     "test_fastp_paired_end - stub": {
         "content": [
@@ -780,8 +755,8 @@
                             "single_end": false
                         },
                         [
-                            "test_R1.fastp.fastq.gz:md5,68b329da9893e34099c7d8ad5cb9c940",
-                            "test_R2.fastp.fastq.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                            "test_1.fastp.fastq.gz:md5,68b329da9893e34099c7d8ad5cb9c940",
+                            "test_2.fastp.fastq.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
                         ]
                     ]
                 ],
@@ -819,11 +794,7 @@
                     
                 ],
                 "6": [
-                    [
-                        "FASTP",
-                        "fastp",
-                        "1.0.1"
-                    ]
+                    "versions.yml:md5,3799377c4173131ba9392346e1c40bb9"
                 ],
                 "html": [
                     [
@@ -859,8 +830,8 @@
                             "single_end": false
                         },
                         [
-                            "test_R1.fastp.fastq.gz:md5,68b329da9893e34099c7d8ad5cb9c940",
-                            "test_R2.fastp.fastq.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                            "test_1.fastp.fastq.gz:md5,68b329da9893e34099c7d8ad5cb9c940",
+                            "test_2.fastp.fastq.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
                         ]
                     ]
                 ],
@@ -870,23 +841,28 @@
                 "reads_merged": [
                     
                 ],
-                "versions_fastp": [
-                    [
-                        "FASTP",
-                        "fastp",
-                        "1.0.1"
-                    ]
+                "versions": [
+                    "versions.yml:md5,3799377c4173131ba9392346e1c40bb9"
                 ]
             }
         ],
         "meta": {
-            "nf-test": "0.9.3",
-            "nextflow": "25.10.2"
+            "nf-test": "0.9.2",
+            "nextflow": "24.10.5"
         },
-        "timestamp": "2026-01-22T13:00:09.585957282"
+        "timestamp": "2025-03-31T13:40:16.309925689"
     },
     "test_fastp_single_end": {
         "content": [
+            [
+                [
+                    {
+                        "id": "test",
+                        "single_end": true
+                    },
+                    "test.fastp.json:md5,81dc86dd695967bb5c015e0a978bf20c"
+                ]
+            ],
             [
                 [
                     {
@@ -902,21 +878,15 @@
             [
                 
             ],
-            {
-                "versions_fastp": [
-                    [
-                        "FASTP",
-                        "fastp",
-                        "1.0.1"
-                    ]
-                ]
-            }
+            [
+                "versions.yml:md5,3799377c4173131ba9392346e1c40bb9"
+            ]
         ],
         "meta": {
-            "nf-test": "0.9.3",
-            "nextflow": "25.10.2"
+            "nf-test": "0.9.2",
+            "nextflow": "24.10.5"
         },
-        "timestamp": "2026-01-23T09:46:19.624824985"
+        "timestamp": "2025-03-31T13:39:07.133909607"
     },
     "test_fastp_single_end_trim_fail - stub": {
         "content": [
@@ -970,11 +940,7 @@
                     
                 ],
                 "6": [
-                    [
-                        "FASTP",
-                        "fastp",
-                        "1.0.1"
-                    ]
+                    "versions.yml:md5,3799377c4173131ba9392346e1c40bb9"
                 ],
                 "html": [
                     [
@@ -1024,20 +990,16 @@
                 "reads_merged": [
                     
                 ],
-                "versions_fastp": [
-                    [
-                        "FASTP",
-                        "fastp",
-                        "1.0.1"
-                    ]
+                "versions": [
+                    "versions.yml:md5,3799377c4173131ba9392346e1c40bb9"
                 ]
             }
         ],
         "meta": {
-            "nf-test": "0.9.3",
-            "nextflow": "25.10.2"
+            "nf-test": "0.9.2",
+            "nextflow": "24.10.5"
         },
-        "timestamp": "2026-01-22T13:00:22.800659826"
+        "timestamp": "2025-03-31T13:40:28.086573661"
     },
     "test_fastp_paired_end_trim_fail - stub": {
         "content": [
@@ -1049,8 +1011,8 @@
                             "single_end": false
                         },
                         [
-                            "test_R1.fastp.fastq.gz:md5,68b329da9893e34099c7d8ad5cb9c940",
-                            "test_R2.fastp.fastq.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                            "test_1.fastp.fastq.gz:md5,68b329da9893e34099c7d8ad5cb9c940",
+                            "test_2.fastp.fastq.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
                         ]
                     ]
                 ],
@@ -1089,8 +1051,8 @@
                         },
                         [
                             "test.paired.fail.fastq.gz:md5,68b329da9893e34099c7d8ad5cb9c940",
-                            "test_R1.fail.fastq.gz:md5,68b329da9893e34099c7d8ad5cb9c940",
-                            "test_R2.fail.fastq.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                            "test_1.fail.fastq.gz:md5,68b329da9893e34099c7d8ad5cb9c940",
+                            "test_2.fail.fastq.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
                         ]
                     ]
                 ],
@@ -1098,11 +1060,7 @@
                     
                 ],
                 "6": [
-                    [
-                        "FASTP",
-                        "fastp",
-                        "1.0.1"
-                    ]
+                    "versions.yml:md5,3799377c4173131ba9392346e1c40bb9"
                 ],
                 "html": [
                     [
@@ -1138,8 +1096,8 @@
                             "single_end": false
                         },
                         [
-                            "test_R1.fastp.fastq.gz:md5,68b329da9893e34099c7d8ad5cb9c940",
-                            "test_R2.fastp.fastq.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                            "test_1.fastp.fastq.gz:md5,68b329da9893e34099c7d8ad5cb9c940",
+                            "test_2.fastp.fastq.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
                         ]
                     ]
                 ],
@@ -1151,28 +1109,24 @@
                         },
                         [
                             "test.paired.fail.fastq.gz:md5,68b329da9893e34099c7d8ad5cb9c940",
-                            "test_R1.fail.fastq.gz:md5,68b329da9893e34099c7d8ad5cb9c940",
-                            "test_R2.fail.fastq.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                            "test_1.fail.fastq.gz:md5,68b329da9893e34099c7d8ad5cb9c940",
+                            "test_2.fail.fastq.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
                         ]
                     ]
                 ],
                 "reads_merged": [
                     
                 ],
-                "versions_fastp": [
-                    [
-                        "FASTP",
-                        "fastp",
-                        "1.0.1"
-                    ]
+                "versions": [
+                    "versions.yml:md5,3799377c4173131ba9392346e1c40bb9"
                 ]
             }
         ],
         "meta": {
-            "nf-test": "0.9.3",
-            "nextflow": "25.10.2"
+            "nf-test": "0.9.2",
+            "nextflow": "24.10.5"
         },
-        "timestamp": "2026-01-22T13:00:30.271734068"
+        "timestamp": "2025-03-31T13:40:35.606162029"
     },
     "fastp test_fastp_interleaved": {
         "content": [
@@ -1185,24 +1139,36 @@
                     "test.fastp.fastq.gz:md5,217d62dc13a23e92513a1bd8e1bcea39"
                 ]
             ],
-            {
-                "versions_fastp": [
-                    [
-                        "FASTP",
-                        "fastp",
-                        "1.0.1"
-                    ]
+            [
+                [
+                    {
+                        "id": "test",
+                        "single_end": true
+                    },
+                    "test.fastp.json:md5,101003b8ac634ca5fd381656ac2b8b9f"
                 ]
-            }
+            ],
+            [
+                "versions.yml:md5,3799377c4173131ba9392346e1c40bb9"
+            ]
         ],
         "meta": {
-            "nf-test": "0.9.3",
-            "nextflow": "25.10.2"
+            "nf-test": "0.9.2",
+            "nextflow": "24.10.5"
         },
-        "timestamp": "2026-01-23T09:46:33.4628687"
+        "timestamp": "2025-03-31T13:39:23.114582408"
     },
     "test_fastp_single_end_trim_fail": {
         "content": [
+            [
+                [
+                    {
+                        "id": "test",
+                        "single_end": true
+                    },
+                    "test.fastp.json:md5,d721f75d68a382c819b6499e6325a942"
+                ]
+            ],
             [
                 [
                     {
@@ -1224,57 +1190,54 @@
             [
                 
             ],
-            {
-                "versions_fastp": [
-                    [
-                        "FASTP",
-                        "fastp",
-                        "1.0.1"
-                    ]
-                ]
-            }
+            [
+                "versions.yml:md5,3799377c4173131ba9392346e1c40bb9"
+            ]
         ],
         "meta": {
-            "nf-test": "0.9.3",
-            "nextflow": "25.10.2"
+            "nf-test": "0.9.2",
+            "nextflow": "24.10.5"
         },
-        "timestamp": "2026-01-23T09:46:39.895973372"
+        "timestamp": "2025-03-31T13:39:30.757538842"
     },
     "test_fastp_paired_end_qc_only": {
         "content": [
             [
-                
-            ],
-            [
-                
-            ],
-            [
-                
-            ],
-            [
-                
-            ],
-            [
-                
-            ],
-            [
-                
-            ],
-            {
-                "versions_fastp": [
-                    [
-                        "FASTP",
-                        "fastp",
-                        "1.0.1"
-                    ]
+                [
+                    {
+                        "id": "test",
+                        "single_end": false
+                    },
+                    "test.fastp.json:md5,1ad31d6559ff5d4d275f501f3f5c02b9"
                 ]
-            }
+            ],
+            [
+                
+            ],
+            [
+                
+            ],
+            [
+                
+            ],
+            [
+                
+            ],
+            [
+                
+            ],
+            [
+                
+            ],
+            [
+                "versions.yml:md5,3799377c4173131ba9392346e1c40bb9"
+            ]
         ],
         "meta": {
-            "nf-test": "0.9.3",
-            "nextflow": "25.10.2"
+            "nf-test": "0.9.2",
+            "nextflow": "24.10.5"
         },
-        "timestamp": "2026-01-23T09:47:13.015833707"
+        "timestamp": "2025-03-31T13:40:01.381972575"
     },
     "test_fastp_paired_end_qc_only - stub": {
         "content": [
@@ -1316,11 +1279,7 @@
                     
                 ],
                 "6": [
-                    [
-                        "FASTP",
-                        "fastp",
-                        "1.0.1"
-                    ]
+                    "versions.yml:md5,3799377c4173131ba9392346e1c40bb9"
                 ],
                 "html": [
                     [
@@ -1358,19 +1317,15 @@
                 "reads_merged": [
                     
                 ],
-                "versions_fastp": [
-                    [
-                        "FASTP",
-                        "fastp",
-                        "1.0.1"
-                    ]
+                "versions": [
+                    "versions.yml:md5,3799377c4173131ba9392346e1c40bb9"
                 ]
             }
         ],
         "meta": {
-            "nf-test": "0.9.3",
-            "nextflow": "25.10.2"
+            "nf-test": "0.9.2",
+            "nextflow": "24.10.5"
         },
-        "timestamp": "2026-01-22T13:00:59.670106791"
+        "timestamp": "2025-03-31T13:40:56.392034947"
     }
 }

--- a/modules/nf-core/fastp/tests/nextflow.interleaved.config
+++ b/modules/nf-core/fastp/tests/nextflow.interleaved.config
@@ -1,0 +1,5 @@
+process {
+    withName: FASTP {
+        ext.args = "--interleaved_in -e 30"
+    }
+}

--- a/modules/nf-core/fastp/tests/nextflow.save_failed.config
+++ b/modules/nf-core/fastp/tests/nextflow.save_failed.config
@@ -1,0 +1,5 @@
+process {
+    withName: FASTP {
+        ext.args = "-e 30"
+    }
+}

--- a/modules/nf-core/filtlong/environment.yml
+++ b/modules/nf-core/filtlong/environment.yml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/environment-schema.json
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  - bioconda::filtlong=0.2.1

--- a/modules/nf-core/filtlong/main.nf
+++ b/modules/nf-core/filtlong/main.nf
@@ -1,0 +1,39 @@
+process FILTLONG {
+    tag "$meta.id"
+    label 'process_low'
+
+    conda "${moduleDir}/environment.yml"
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/filtlong:0.2.1--h9a82719_0' :
+        'biocontainers/filtlong:0.2.1--h9a82719_0' }"
+
+    input:
+    tuple val(meta), path(shortreads), path(longreads)
+
+    output:
+    tuple val(meta), path("*.fastq.gz"), emit: reads
+    tuple val(meta), path("*.log")     , emit: log
+    path "versions.yml"                 , emit: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args = task.ext.args ?: ''
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    def short_reads = !shortreads ? "" : meta.single_end ? "-1 $shortreads" : "-1 ${shortreads[0]} -2 ${shortreads[1]}"
+    if ("$longreads" == "${prefix}.fastq.gz") error "Longread FASTQ input and output names are the same, set prefix in module configuration to disambiguate!"
+    """
+    filtlong \\
+        $short_reads \\
+        $args \\
+        $longreads \\
+        2>| >(tee ${prefix}.log >&2) \\
+        | gzip -n > ${prefix}.fastq.gz
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        filtlong: \$( filtlong --version | sed -e "s/Filtlong v//g" )
+    END_VERSIONS
+    """
+}

--- a/modules/nf-core/filtlong/meta.yml
+++ b/modules/nf-core/filtlong/meta.yml
@@ -1,0 +1,74 @@
+name: filtlong
+description: Filtlong filters long reads based on quality measures or short read data.
+keywords:
+  - nanopore
+  - quality control
+  - QC
+  - filtering
+  - long reads
+  - short reads
+tools:
+  - filtlong:
+      description: Filtlong is a tool for filtering long reads. It can take a set of
+        long reads and produce a smaller, better subset. It uses both read length (longer
+        is better) and read identity (higher is better) when choosing which reads pass
+        the filter.
+      homepage: https://anaconda.org/bioconda/filtlong
+      tool_dev_url: https://github.com/rrwick/Filtlong
+      licence: ["GPL v3"]
+      identifier: biotools:filtlong
+input:
+  - - meta:
+        type: map
+        description: |
+          Groovy Map containing sample information
+          e.g. [ id:'test', single_end:false ]
+    - shortreads:
+        type: file
+        description: fastq file
+        pattern: "*.{fq,fastq,fq.gz,fastq.gz}"
+        ontologies:
+          - edam: http://edamontology.org/format_1930 # FASTQ
+    - longreads:
+        type: file
+        description: fastq file
+        pattern: "*.{fq,fastq,fq.gz,fastq.gz}"
+        ontologies:
+          - edam: http://edamontology.org/format_1930 # FASTQ
+output:
+  reads:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. [ id:'test', single_end:false ]
+      - "*.fastq.gz":
+          type: file
+          description: Filtered (compressed) fastq file
+          pattern: "*.fastq.gz"
+          ontologies:
+            - edam: http://edamontology.org/format_3989 # GZIP format
+  log:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. [ id:'test', single_end:false ]
+      - "*.log":
+          type: file
+          description: Standard error logging file containing summary statistics
+          pattern: "*.log"
+          ontologies: []
+  versions:
+    - versions.yml:
+        type: file
+        description: File containing software versions
+        pattern: "versions.yml"
+        ontologies:
+          - edam: http://edamontology.org/format_3750 # YAML
+authors:
+  - "@d4straub"
+  - "@sofstam"
+maintainers:
+  - "@d4straub"
+  - "@sofstam"

--- a/modules/nf-core/filtlong/tests/main.nf.test
+++ b/modules/nf-core/filtlong/tests/main.nf.test
@@ -1,0 +1,108 @@
+nextflow_process {
+
+    name "Test Process FILTLONG"
+    script "../main.nf"
+    process "FILTLONG"
+    config "./nextflow.config"
+    tag "filtlong"
+    tag "modules"
+    tag "modules_nfcore"
+
+    test("sarscov2 nanopore [fastq]") {
+
+        when {
+            params {
+                outdir = "$outputDir"
+            }
+            process {
+                """
+                input[0] = [
+                    [ id:'test', single_end:false ], // meta map
+                    [],
+                    [ file(params.modules_testdata_base_path + 'genomics/sarscov2/nanopore/fastq/test.fastq.gz', checkIfExists: true) ]
+                ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert path(process.out.log.get(0).get(1)).readLines().contains("Scoring long reads")},
+                { assert snapshot(
+                    process.out.reads,
+                    process.out.versions
+                    ).match()
+                }
+            )
+        }
+
+    }
+
+
+    test("sarscov2 nanopore [fastq] + Illumina single-end [fastq]") {
+
+        when {
+            params {
+                outdir = "$outputDir"
+            }
+            process {
+                """
+                input[0] = [
+                    [ id:'test', single_end:true ], // meta map
+                    [ file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true) ],
+                    [ file(params.modules_testdata_base_path + 'genomics/sarscov2/nanopore/fastq/test.fastq.gz', checkIfExists: true) ]
+                ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert path(process.out.log.get(0).get(1)).readLines().contains("Scoring long reads")},
+                { assert snapshot(
+                    process.out.reads,
+                    process.out.versions
+                    ).match()
+                }
+            )
+        }
+
+    }
+
+
+    test("sarscov2 nanopore [fastq] + Illumina paired-end [fastq]") {
+
+        when {
+            params {
+                outdir = "$outputDir"
+            }
+            process {
+                """
+                input[0] = [
+                    [ id:'test', single_end:false ], // meta map
+                    [
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true),
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_2.fastq.gz', checkIfExists: true)
+                    ],
+                    [ file(params.modules_testdata_base_path + 'genomics/sarscov2/nanopore/fastq/test.fastq.gz', checkIfExists: true) ]
+                ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert path(process.out.log.get(0).get(1)).readLines().contains("Scoring long reads")},
+                { assert snapshot(
+                    process.out.reads,
+                    process.out.versions
+                    ).match()
+                }
+            )
+        }
+
+    }
+}

--- a/modules/nf-core/filtlong/tests/main.nf.test.snap
+++ b/modules/nf-core/filtlong/tests/main.nf.test.snap
@@ -1,0 +1,65 @@
+{
+    "sarscov2 nanopore [fastq]": {
+        "content": [
+            [
+                [
+                    {
+                        "id": "test",
+                        "single_end": false
+                    },
+                    "test_lr.fastq.gz:md5,7567d853ada6ac142332619d0b541d76"
+                ]
+            ],
+            [
+                "versions.yml:md5,af5988f30157282acdb0ac50ebb4c8cc"
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "24.04.3"
+        },
+        "timestamp": "2024-08-06T10:51:29.197603"
+    },
+    "sarscov2 nanopore [fastq] + Illumina paired-end [fastq]": {
+        "content": [
+            [
+                [
+                    {
+                        "id": "test",
+                        "single_end": false
+                    },
+                    "test_lr.fastq.gz:md5,7567d853ada6ac142332619d0b541d76"
+                ]
+            ],
+            [
+                "versions.yml:md5,af5988f30157282acdb0ac50ebb4c8cc"
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "24.04.3"
+        },
+        "timestamp": "2024-08-06T10:51:39.68464"
+    },
+    "sarscov2 nanopore [fastq] + Illumina single-end [fastq]": {
+        "content": [
+            [
+                [
+                    {
+                        "id": "test",
+                        "single_end": true
+                    },
+                    "test_lr.fastq.gz:md5,7567d853ada6ac142332619d0b541d76"
+                ]
+            ],
+            [
+                "versions.yml:md5,af5988f30157282acdb0ac50ebb4c8cc"
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "24.04.3"
+        },
+        "timestamp": "2024-08-06T10:51:34.404022"
+    }
+}

--- a/modules/nf-core/filtlong/tests/nextflow.config
+++ b/modules/nf-core/filtlong/tests/nextflow.config
@@ -1,0 +1,4 @@
+process {
+    ext.args = "--min_length 10"
+    ext.prefix = "test_lr"
+}

--- a/modules/nf-core/nanoq/environment.yml
+++ b/modules/nf-core/nanoq/environment.yml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/environment-schema.json
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  - bioconda::nanoq=0.10.0

--- a/modules/nf-core/nanoq/main.nf
+++ b/modules/nf-core/nanoq/main.nf
@@ -1,0 +1,49 @@
+process NANOQ {
+    tag "${meta.id}"
+    label 'process_low'
+
+    conda "${moduleDir}/environment.yml"
+    container "${workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container
+        ? 'https://depot.galaxyproject.org/singularity/nanoq:0.10.0--h031d066_2'
+        : 'biocontainers/nanoq:0.10.0--h031d066_2'}"
+
+    input:
+    tuple val(meta), path(ontreads)
+    val(output_format) //One of the following: fastq, fastq.gz, fastq.bz2, fastq.lzma, fasta, fasta.gz, fasta.bz2, fasta.lzma.
+
+    output:
+    tuple val(meta), path("*.{stats,json}")            , emit: stats
+    tuple val(meta), path("${prefix}.${output_format}"), emit: reads
+    path "versions.yml"                                , emit: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args = task.ext.args ?: ''
+    prefix = task.ext.prefix ?: "${meta.id}_filtered"
+    """
+    nanoq -i ${ontreads} \\
+        ${args} \\
+        -r ${prefix}.stats \\
+        -o ${prefix}.${output_format}
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        nanoq: \$(nanoq --version | sed -e 's/nanoq //g')
+    END_VERSIONS
+    """
+
+    stub:
+    def args = task.ext.args ?: ''
+    prefix = task.ext.prefix ?: "${meta.id}_filtered"
+    """
+    echo "" | gzip > ${prefix}.${output_format}
+    touch ${prefix}.stats
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        nanoq: \$(nanoq --version | sed -e 's/nanoq //g')
+    END_VERSIONS
+    """
+}

--- a/modules/nf-core/nanoq/meta.yml
+++ b/modules/nf-core/nanoq/meta.yml
@@ -1,0 +1,71 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/meta-schema.json
+name: "nanoq"
+description: Nanoq implements ultra-fast read filters and summary reports for high-throughput
+  nanopore reads.
+keywords:
+  - nanoq
+  - Read filters
+  - Read trimming
+  - Read report
+tools:
+  - "nanoq":
+      description: "Ultra-fast quality control and summary reports for nanopore reads"
+      homepage: "https://github.com/esteinig/nanoq"
+      documentation: "https://github.com/esteinig/nanoq"
+      tool_dev_url: "https://github.com/esteinig/nanoq"
+      doi: "10.21105/joss.02991"
+      licence: ["MIT"]
+      identifier: ""
+
+input:
+  - - meta:
+        type: map
+        description: |
+          Groovy Map containing sample information
+          e.g. `[ id:'sample1', single_end:false ]`
+    - ontreads:
+        type: file
+        description: Compressed or uncompressed nanopore reads in fasta or fastq formats.
+        pattern: "*.{fa,fna,faa,fasta,fq,fastq}{,.gz,.bz2,.xz}"
+        ontologies:
+          - edam: http://edamontology.org/format_1930 # FASTQ
+  - output_format:
+      type: string
+      description: "Specifies the output format. One of these formats: fasta, fastq;
+        fasta.gz, fastq.gz; fasta.bz2, fastq.bz2; fasta.lzma, fastq.lzma."
+output:
+  stats:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. `[ id:'sample1', single_end:false ]`
+      - "*.{stats,json}":
+          type: file
+          description: Summary report of reads statistics.
+          pattern: "*.{stats,json}"
+          ontologies:
+            - edam: http://edamontology.org/format_3464 # JSON
+  reads:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. `[ id:'sample1', single_end:false ]`
+      - ${prefix}.${output_format}:
+          type: file
+          description: Filtered reads.
+          pattern: "*.{fasta,fastq}{,.gz,.bz2,.lzma}"
+          ontologies:
+            - edam: http://edamontology.org/format_1930 # FASTQ
+  versions:
+    - versions.yml:
+        type: file
+        description: File containing software versions
+        pattern: "versions.yml"
+        ontologies:
+          - edam: http://edamontology.org/format_3750 # YAML
+authors:
+  - "@LilyAnderssonLee"
+maintainers:
+  - "@LilyAnderssonLee"

--- a/modules/nf-core/nanoq/tests/main.nf.test
+++ b/modules/nf-core/nanoq/tests/main.nf.test
@@ -1,0 +1,122 @@
+nextflow_process {
+
+    name "Test Process NANOQ"
+    script "../main.nf"
+    process "NANOQ"
+
+    tag "modules"
+    tag "modules_nfcore"
+    tag "nanoq"
+
+    test("sarscov2 - nanopore_uncompressed") {
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test', single_end:true ], // meta map
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/nanopore/fastq/test.fastq.gz', checkIfExists: true)
+                ]
+
+                input[1] = 'fastq'
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+    }
+
+    test("sarscov2 - nanopore_compressed_gz") {
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test', single_end:true ], // meta map
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/nanopore/fastq/test.fastq.gz', checkIfExists: true)
+                ]
+                input[1] = 'fastq.gz'
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+    }
+    test("sarscov2 - nanopore_compressed_bz2") {
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test', single_end:true ], // meta map
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/nanopore/fastq/test.fastq.gz', checkIfExists: true)
+                ]
+                input[1] = 'fastq.bz2'
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+    }
+    test("sarscov2 - nanopore_compressed_lzma") {
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test', single_end:true ], // meta map
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/nanopore/fastq/test.fastq.gz', checkIfExists: true)
+                ]
+                input[1] = 'fastq.lzma'
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+    }
+
+    test("sarscov2 - nanopore_compressed_gz - stub") {
+
+        options "-stub"
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test', single_end:true ], // meta map
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/nanopore/fastq/test.fastq.gz', checkIfExists: true)
+                    ]
+                    input[1] = 'fastq.gz'
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+
+    }
+}

--- a/modules/nf-core/nanoq/tests/main.nf.test.snap
+++ b/modules/nf-core/nanoq/tests/main.nf.test.snap
@@ -1,0 +1,267 @@
+{
+    "sarscov2 - nanopore_compressed_gz": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": true
+                        },
+                        "test_filtered.stats:md5,5ab32af3352dfeca8268e10edf6e4dbe"
+                    ]
+                ],
+                "1": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": true
+                        },
+                        "test_filtered.fastq.gz:md5,7567d853ada6ac142332619d0b541d76"
+                    ]
+                ],
+                "2": [
+                    "versions.yml:md5,7a40efe417ff7dbb9e91e9c1629a04e6"
+                ],
+                "reads": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": true
+                        },
+                        "test_filtered.fastq.gz:md5,7567d853ada6ac142332619d0b541d76"
+                    ]
+                ],
+                "stats": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": true
+                        },
+                        "test_filtered.stats:md5,5ab32af3352dfeca8268e10edf6e4dbe"
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,7a40efe417ff7dbb9e91e9c1629a04e6"
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "23.04.1"
+        },
+        "timestamp": "2024-07-11T11:39:32.117229"
+    },
+    "sarscov2 - nanopore_compressed_gz - stub": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": true
+                        },
+                        "test_filtered.stats:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "1": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": true
+                        },
+                        "test_filtered.fastq.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                    ]
+                ],
+                "2": [
+                    "versions.yml:md5,7a40efe417ff7dbb9e91e9c1629a04e6"
+                ],
+                "reads": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": true
+                        },
+                        "test_filtered.fastq.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                    ]
+                ],
+                "stats": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": true
+                        },
+                        "test_filtered.stats:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,7a40efe417ff7dbb9e91e9c1629a04e6"
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "23.04.1"
+        },
+        "timestamp": "2024-07-11T11:42:06.039307"
+    },
+    "sarscov2 - nanopore_compressed_bz2": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": true
+                        },
+                        "test_filtered.stats:md5,5ab32af3352dfeca8268e10edf6e4dbe"
+                    ]
+                ],
+                "1": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": true
+                        },
+                        "test_filtered.fastq.bz2:md5,b53cf14fd4eb5b16c459c41f03cc8a4b"
+                    ]
+                ],
+                "2": [
+                    "versions.yml:md5,7a40efe417ff7dbb9e91e9c1629a04e6"
+                ],
+                "reads": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": true
+                        },
+                        "test_filtered.fastq.bz2:md5,b53cf14fd4eb5b16c459c41f03cc8a4b"
+                    ]
+                ],
+                "stats": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": true
+                        },
+                        "test_filtered.stats:md5,5ab32af3352dfeca8268e10edf6e4dbe"
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,7a40efe417ff7dbb9e91e9c1629a04e6"
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "23.04.1"
+        },
+        "timestamp": "2024-07-11T11:39:36.674647"
+    },
+    "sarscov2 - nanopore_compressed_lzma": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": true
+                        },
+                        "test_filtered.stats:md5,5ab32af3352dfeca8268e10edf6e4dbe"
+                    ]
+                ],
+                "1": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": true
+                        },
+                        "test_filtered.fastq.lzma:md5,65dda701689f913734dc245b68c89e07"
+                    ]
+                ],
+                "2": [
+                    "versions.yml:md5,7a40efe417ff7dbb9e91e9c1629a04e6"
+                ],
+                "reads": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": true
+                        },
+                        "test_filtered.fastq.lzma:md5,65dda701689f913734dc245b68c89e07"
+                    ]
+                ],
+                "stats": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": true
+                        },
+                        "test_filtered.stats:md5,5ab32af3352dfeca8268e10edf6e4dbe"
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,7a40efe417ff7dbb9e91e9c1629a04e6"
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "23.04.1"
+        },
+        "timestamp": "2024-07-11T11:39:41.51344"
+    },
+    "sarscov2 - nanopore_uncompressed": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": true
+                        },
+                        "test_filtered.stats:md5,5ab32af3352dfeca8268e10edf6e4dbe"
+                    ]
+                ],
+                "1": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": true
+                        },
+                        "test_filtered.fastq:md5,7567d853ada6ac142332619d0b541d76"
+                    ]
+                ],
+                "2": [
+                    "versions.yml:md5,7a40efe417ff7dbb9e91e9c1629a04e6"
+                ],
+                "reads": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": true
+                        },
+                        "test_filtered.fastq:md5,7567d853ada6ac142332619d0b541d76"
+                    ]
+                ],
+                "stats": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": true
+                        },
+                        "test_filtered.stats:md5,5ab32af3352dfeca8268e10edf6e4dbe"
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,7a40efe417ff7dbb9e91e9c1629a04e6"
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "23.04.1"
+        },
+        "timestamp": "2024-07-11T11:39:26.868897"
+    }
+}

--- a/modules/nf-core/porechop/abi/environment.yml
+++ b/modules/nf-core/porechop/abi/environment.yml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/environment-schema.json
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  - bioconda::porechop_abi=0.5.0

--- a/modules/nf-core/porechop/abi/main.nf
+++ b/modules/nf-core/porechop/abi/main.nf
@@ -1,0 +1,50 @@
+process PORECHOP_ABI {
+    tag "$meta.id"
+    label 'process_medium'
+
+    conda "${moduleDir}/environment.yml"
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/porechop_abi:0.5.0--py310h590eda1_0':
+        'biocontainers/porechop_abi:0.5.0--py310h590eda1_0' }"
+
+    input:
+    tuple val(meta), path(reads)
+
+    output:
+    tuple val(meta), path("*.fastq.gz") , emit: reads
+    tuple val(meta), path("*.log")      , emit: log
+    path "versions.yml"                 , emit: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args = task.ext.args ?: ''
+    def prefix = task.ext.prefix ?: "${meta.id}.porechop_abi"
+    if ("$reads" == "${prefix}.fastq.gz") error "Input and output names are the same, use \"task.ext.prefix\" to disambiguate!"
+    """
+    porechop_abi \\
+        --input $reads \\
+        --threads $task.cpus \\
+        $args \\
+        --output ${prefix}.fastq.gz \\
+        | tee ${prefix}.log
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        porechop_abi: \$( porechop_abi --version )
+    END_VERSIONS
+    """
+
+    stub:
+    def args = task.ext.args ?: ''
+    def prefix = task.ext.prefix ?: "${meta.id}.porechop_abi"
+    """
+    echo "" | gzip > ${prefix}.fastq.gz
+    touch ${prefix}.log
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        porechop_abi: \$( porechop_abi --version )
+    END_VERSIONS
+    """
+}

--- a/modules/nf-core/porechop/abi/meta.yml
+++ b/modules/nf-core/porechop/abi/meta.yml
@@ -1,0 +1,48 @@
+name: "porechop_abi"
+description: Extension of Porechop whose purpose is to process adapter sequences in ONT reads.
+keywords:
+  - porechop_abi
+  - adapter
+  - nanopore
+tools:
+  - "porechop_abi":
+      description: Extension of Porechop whose purpose is to process adapter sequences in ONT reads.
+      homepage: "https://github.com/bonsai-team/Porechop_ABI"
+      documentation: "https://github.com/bonsai-team/Porechop_ABI"
+      tool_dev_url: "https://github.com/bonsai-team/Porechop_ABI"
+      doi: "10.1101/2022.07.07.499093"
+      licence: ["MIT"]
+input:
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. [ id:'test', single_end:false ]
+  - reads:
+      type: file
+      description: fastq/fastq.gz file
+      pattern: "*.{fastq,fastq.gz,fq,fq.gz}"
+output:
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. [ id:'test', single_end:false ]
+  - versions:
+      type: file
+      description: File containing software versions
+      pattern: "versions.yml"
+  - reads:
+      type: file
+      description: Adapter-trimmed fastq.gz file
+      pattern: "*.fastq.gz"
+  - log:
+      type: file
+      description: Log file containing stdout information
+      pattern: "*.log"
+authors:
+  - "@sofstam"
+  - "LilyAnderssonLee"
+maintainers:
+  - "@sofstam"
+  - "LilyAnderssonLee"

--- a/modules/nf-core/porechop/abi/tests/main.nf.test
+++ b/modules/nf-core/porechop/abi/tests/main.nf.test
@@ -1,0 +1,59 @@
+nextflow_process {
+
+    name "Test Process PORECHOP_ABI"
+    script "../main.nf"
+    process "PORECHOP_ABI"
+    tag "modules"
+    tag "modules_nfcore"
+    tag "porechop"
+    tag "porechop/abi"
+
+    test("sarscov2-nanopore") {
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test'], // meta map
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/nanopore/fastq/test.fastq.gz', checkIfExists: true)
+                ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(
+                    process.out.reads,
+                    file(process.out.log.get(0).get(1)).readLines()[20..40],
+                    process.out.versions).match()
+                }
+            )
+        }
+    }
+
+    test("sarscov2-nanopore - stub") {
+
+        options "-stub"
+
+        when {
+
+            process {
+                """
+                input[0] = [
+                    [ id:'test'], // meta map
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/nanopore/fastq/test.fastq.gz', checkIfExists: true)
+                ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+    }
+}

--- a/modules/nf-core/porechop/abi/tests/main.nf.test.snap
+++ b/modules/nf-core/porechop/abi/tests/main.nf.test.snap
@@ -1,0 +1,94 @@
+{
+    "sarscov2-nanopore": {
+        "content": [
+            [
+                [
+                    {
+                        "id": "test"
+                    },
+                    "test.porechop_abi.fastq.gz:md5,886fdb859fb50e0dddd35007bcff043e"
+                ]
+            ],
+            [
+                "                                        Best               \u001b[0m",
+                "                                        read       Best    \u001b[0m",
+                "                                        start      read end\u001b[0m",
+                "  \u001b[4mSet                                   %ID        %ID     \u001b[0m",
+                "  \u001b[32mSQK-NSK007                               100.0       73.1\u001b[0m",
+                "  Rapid                                     40.4        0.0",
+                "  RBK004_upstream                           77.5        0.0",
+                "  SQK-MAP006                                75.8       72.7",
+                "  SQK-MAP006 short                          65.5       66.7",
+                "  PCR adapters 1                            73.9       69.6",
+                "  PCR adapters 2                            80.0       72.7",
+                "  PCR adapters 3                            70.8       69.6",
+                "  1D^2 part 1                               71.4       70.0",
+                "  1D^2 part 2                               84.8       75.8",
+                "  cDNA SSP                                  63.0       61.7",
+                "  \u001b[32mBarcode 1 (reverse)                      100.0      100.0\u001b[0m",
+                "  Barcode 2 (reverse)                       70.8       69.2",
+                "  Barcode 3 (reverse)                       76.0       70.4",
+                "  Barcode 4 (reverse)                       74.1       71.4",
+                "  Barcode 5 (reverse)                       77.8       80.8",
+                "  Barcode 6 (reverse)                       73.1       70.8"
+            ],
+            [
+                "versions.yml:md5,0e9e5e0d35a68ff8e6490c949b257f98"
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "23.04.1"
+        },
+        "timestamp": "2024-07-29T13:50:49.318599"
+    },
+    "sarscov2-nanopore - stub": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.porechop_abi.fastq.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                    ]
+                ],
+                "1": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.porechop_abi.log:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "2": [
+                    "versions.yml:md5,0e9e5e0d35a68ff8e6490c949b257f98"
+                ],
+                "log": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.porechop_abi.log:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "reads": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.porechop_abi.fastq.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,0e9e5e0d35a68ff8e6490c949b257f98"
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "23.04.1"
+        },
+        "timestamp": "2024-07-29T13:50:54.425389"
+    }
+}

--- a/modules/nf-core/porechop/porechop/environment.yml
+++ b/modules/nf-core/porechop/porechop/environment.yml
@@ -1,0 +1,8 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/environment-schema.json
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  - bioconda::porechop=0.2.4
+  - conda-forge::pigz=2.8

--- a/modules/nf-core/porechop/porechop/main.nf
+++ b/modules/nf-core/porechop/porechop/main.nf
@@ -1,0 +1,51 @@
+process PORECHOP_PORECHOP {
+    tag "$meta.id"
+    label 'process_medium'
+
+    conda "${moduleDir}/environment.yml"
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?        
+        'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/2b/2bce1f10c51906a66c4c4d3a7485394f67e304177192ad1cce6cf586a3a18bae/data' :
+        'community.wave.seqera.io/library/porechop_pigz:d1655e5b5bad786c' }"
+
+
+    input:
+    tuple val(meta), path(reads)
+
+    output:
+    tuple val(meta), path("*.fastq.gz"), emit: reads
+    tuple val(meta), path("*.log")     , emit: log
+    path "versions.yml"                , emit: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args = task.ext.args ?: ''
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    if ("$reads" == "${prefix}.fastq.gz") error "Input and output names are the same, use \"task.ext.prefix\" to disambiguate!"
+    """
+    porechop \\
+        -i $reads \\
+        -t $task.cpus \\
+        $args \\
+        -o ${prefix}.fastq.gz \\
+        > ${prefix}.log
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        porechop: \$( porechop --version )
+    END_VERSIONS
+    """
+
+    stub:
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    """
+    touch ${prefix}.fastq
+    gzip ${prefix}.fastq
+    touch ${prefix}.log
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        porechop: \$( porechop --version )
+    END_VERSIONS
+    """
+}

--- a/modules/nf-core/porechop/porechop/meta.yml
+++ b/modules/nf-core/porechop/porechop/meta.yml
@@ -1,0 +1,77 @@
+name: "porechop_porechop"
+description: Adapter removal and demultiplexing of Oxford Nanopore reads
+keywords:
+  - adapter
+  - nanopore
+  - demultiplexing
+tools:
+  - porechop:
+      description: Adapter removal and demultiplexing of Oxford Nanopore reads
+      homepage: "https://github.com/rrwick/Porechop"
+      documentation: "https://github.com/rrwick/Porechop"
+      tool_dev_url: "https://github.com/rrwick/Porechop"
+      doi: "10.1099/mgen.0.000132"
+      licence: ["GPL v3"]
+      identifier: ""
+input:
+  - - meta:
+        type: map
+        description: |
+          Groovy Map containing sample information
+          e.g. [ id:'test', single_end:false ]
+    - reads:
+        type: file
+        description: fastq/fastq.gz file
+        pattern: "*.{fastq,fastq.gz,fq,fq.gz}"
+        ontologies:
+          - edam: http://edamontology.org/format_1930 # FASTQ
+output:
+  reads:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. [ id:'test', single_end:false ]
+      - "*.fastq.gz":
+          type: file
+          description: Demultiplexed and/or adapter-trimmed fastq.gz file
+          pattern: "*.{fastq.gz}"
+          ontologies: []
+  log:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. [ id:'test', single_end:false ]
+      - "*.log":
+          type: file
+          description: Log file containing stdout information
+          pattern: "*.log"
+          ontologies: []
+  versions:
+    - versions.yml:
+        type: file
+        description: File containing software versions
+        pattern: "versions.yml"
+        ontologies:
+          - edam: http://edamontology.org/format_3750 # YAML
+authors:
+  - "@ggabernet"
+  - "@jasmezz"
+  - "@d4straub"
+  - "@LaurenceKuhl"
+  - "@SusiJo"
+  - "@jonasscheid"
+  - "@jonoave"
+  - "@GokceOGUZ"
+  - "@jfy133"
+maintainers:
+  - "@ggabernet"
+  - "@jasmezz"
+  - "@d4straub"
+  - "@LaurenceKuhl"
+  - "@SusiJo"
+  - "@jonasscheid"
+  - "@jonoave"
+  - "@GokceOGUZ"
+  - "@jfy133"

--- a/modules/nf-core/porechop/porechop/porechop-porechop.diff
+++ b/modules/nf-core/porechop/porechop/porechop-porechop.diff
@@ -1,0 +1,27 @@
+Changes in component 'nf-core/porechop/porechop'
+'modules/nf-core/porechop/porechop/environment.yml' is unchanged
+'modules/nf-core/porechop/porechop/meta.yml' is unchanged
+Changes in 'porechop/porechop/main.nf':
+--- modules/nf-core/porechop/porechop/main.nf
++++ modules/nf-core/porechop/porechop/main.nf
+@@ -22,6 +22,7 @@
+     script:
+     def args = task.ext.args ?: ''
+     def prefix = task.ext.prefix ?: "${meta.id}"
++    if ("$reads" == "${prefix}.fastq.gz") error "Input and output names are the same, use \"task.ext.prefix\" to disambiguate!"
+     """
+     porechop \\
+         -i $reads \\
+@@ -29,6 +30,7 @@
+         $args \\
+         -o ${prefix}.fastq.gz \\
+         > ${prefix}.log
++
+     cat <<-END_VERSIONS > versions.yml
+     "${task.process}":
+         porechop: \$( porechop --version )
+
+'modules/nf-core/porechop/porechop/tests/main.nf.test.snap' is unchanged
+'modules/nf-core/porechop/porechop/tests/nextflow.config' is unchanged
+'modules/nf-core/porechop/porechop/tests/main.nf.test' is unchanged
+************************************************************

--- a/modules/nf-core/porechop/porechop/tests/main.nf.test
+++ b/modules/nf-core/porechop/porechop/tests/main.nf.test
@@ -1,0 +1,62 @@
+nextflow_process {
+
+    name "Test Process PORECHOP_PORECHOP"
+    script "../main.nf"
+    process "PORECHOP_PORECHOP"
+    config "./nextflow.config"
+
+    tag "modules"
+    tag "modules_nfcore"
+    tag "porechop"
+    tag "porechop/porechop"
+
+    test("sarscov2 - nanopore - fastq") {
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test', single_end:true ],
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/nanopore/fastq/test.fastq.gz', checkIfExists: true)
+                ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out.reads).match("reads") },
+                { assert snapshot(process.out.versions).match("versions") },
+                // complete log is not stable. These first lines should be stable
+                { assert snapshot(path(process.out.log.get(0).get(1)).readLines()[0..7]).match("log")}
+            )
+        }
+
+    }
+
+
+    test("stub") {
+        options "-stub"
+
+        when {
+            process {
+                """
+                input[0] = [ [ id:'test', single_end:true ],
+                    []
+                ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+
+    }
+
+
+}

--- a/modules/nf-core/porechop/porechop/tests/main.nf.test.snap
+++ b/modules/nf-core/porechop/porechop/tests/main.nf.test.snap
@@ -1,0 +1,88 @@
+{
+    "versions": {
+        "content": [
+            [
+                "versions.yml:md5,712c0753b56d0fb530092dfb5bdf2e5c"
+            ]
+        ],
+        "timestamp": "2023-12-18T07:47:16.83444"
+    },
+    "log": {
+        "content": [
+            [
+                "",
+                "\u001b[1m\u001b[4mLoading reads\u001b[0m",
+                "test.fastq.gz",
+                "100 reads loaded",
+                "",
+                "",
+                "\u001b[1m\u001b[4mLooking for known adapter sets\u001b[0m",
+                ""
+            ]
+        ],
+        "timestamp": "2023-12-18T07:47:16.853899"
+    },
+    "reads": {
+        "content": [
+            [
+                [
+                    {
+                        "id": "test",
+                        "single_end": true
+                    },
+                    "test_porechop.fastq.gz:md5,886fdb859fb50e0dddd35007bcff043e"
+                ]
+            ]
+        ],
+        "timestamp": "2023-12-18T07:47:16.811393"
+    },
+    "stub": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": true
+                        },
+                        "test_porechop.fastq.gz:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "1": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": true
+                        },
+                        "test_porechop.log:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "2": [
+                    "versions.yml:md5,712c0753b56d0fb530092dfb5bdf2e5c"
+                ],
+                "log": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": true
+                        },
+                        "test_porechop.log:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "reads": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": true
+                        },
+                        "test_porechop.fastq.gz:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,712c0753b56d0fb530092dfb5bdf2e5c"
+                ]
+            }
+        ],
+        "timestamp": "2023-12-18T07:47:37.814949"
+    }
+}

--- a/modules/nf-core/porechop/porechop/tests/nextflow.config
+++ b/modules/nf-core/porechop/porechop/tests/nextflow.config
@@ -1,0 +1,9 @@
+process {
+
+
+    withName: PORECHOP_PORECHOP {
+        ext.args = ''
+        ext.prefix = { "${meta.id}_porechop" }
+    }
+
+}

--- a/nextflow.config
+++ b/nextflow.config
@@ -36,8 +36,11 @@ params {
     help_full                    = false
     show_hidden                  = false
     version                      = false
-    pipelines_testdata_base_path = 'https://raw.githubusercontent.com/nickp60/test-datasets/'
-    trace_report_suffix          = new java.util.Date().format( 'yyyy-MM-dd_HH-mm-ss')// Config options
+    pipelines_testdata_base_path = 'https://raw.githubusercontent.com/vinisalazar/test-datasets/refs/heads/taxprofiler/' // I don't care about what fork we use, but we should probably decide whether to have the refs/heads/taxprofiler/ suffix or not (can replace by funcprofiler later)
+    modules_testdata_base_path   = 'https://raw.githubusercontent.com/nf-core/test-datasets/modules/data/'
+    trace_report_suffix          = new java.util.Date().format( 'yyyy-MM-dd_HH-mm-ss')
+    
+    // Config options
     config_profile_name        = null
     config_profile_description = null
 
@@ -48,12 +51,66 @@ params {
 
     // Schema validation default options
     validate_params            = true
+
     // Databases
     databases               = null
     save_untarred_databases = false
 
     // FASTQ preprocessing
-    skip_preprocessing_qc            = false
+    skip_preprocessing_qc                                = false
+    preprocessing_qc_tool                                = 'fastqc'
+
+    perform_shortread_qc                                 = false
+    shortread_qc_tool                                    = 'fastp'
+    shortread_qc_skipadaptertrim                         = false
+    shortread_qc_mergepairs                              = false
+    shortread_qc_includeunmerged                         = false
+    shortread_qc_adapter1                                = null
+    shortread_qc_adapter2                                = null
+    shortread_qc_adapterlist                             = null
+    shortread_qc_minlength                               = 15
+    shortread_qc_dedup                                   = false
+
+    perform_longread_qc                                  = false
+    longread_adapterremoval_tool                         = 'porechop_abi'
+    longread_qc_skipadaptertrim                          = false
+    longread_qc_skipqualityfilter                        = false
+    longread_filter_tool                                 = 'nanoq'
+    longread_qc_qualityfilter_minlength                  = 1000
+    longread_qc_qualityfilter_keeppercent                = 90
+    longread_qc_qualityfilter_minquality                 = 7
+    longread_qc_qualityfilter_targetbases                = 500000000
+
+    save_preprocessed_reads                              = false
+
+    // Redundancy estimation
+    perform_shortread_redundancyestimation               = false
+    shortread_redundancyestimation_mode                  = 'kmer'
+
+    // Complexity filtering
+    perform_shortread_complexityfilter                   = false
+    shortread_complexityfilter_tool                      = 'bbduk'
+    shortread_complexityfilter_entropy                   = 0.3
+    shortread_complexityfilter_bbduk_windowsize          = 50
+    shortread_complexityfilter_bbduk_mask                = false
+    shortread_complexityfilter_prinseqplusplus_mode      = 'entropy'
+    shortread_complexityfilter_prinseqplusplus_dustscore = 0.5
+    shortread_complexityfilter_fastp_threshold           = 30
+    save_complexityfiltered_reads                        = false
+
+    // run merging
+    perform_runmerging                                   = false
+    save_runmerged_reads                                 = false
+
+    // Host Removal
+    perform_shortread_hostremoval                        = false
+    perform_longread_hostremoval                         = false
+    hostremoval_reference                                = null
+    shortread_hostremoval_index                          = null
+    longread_hostremoval_index                           = null
+    save_hostremoval_index                               = false
+    save_hostremoval_bam                                 = false
+    save_hostremoval_unmapped                            = false
 
     // RGI
     run_rgi                   = false
@@ -257,8 +314,16 @@ manifest {
             affiliation: '',
             email: '',
             github: '',
-            contribution: [], // List of contribution types ('author', 'maintainer' or 'contributor')
+            contribution: ['author'], // List of contribution types ('author', 'maintainer' or 'contributor')
             orcid: ''
+        ],
+        [
+            name: 'Vini Salazar',
+            affiliation: 'Melbourne Bioinformatics, University of Melbourne',
+            email: '',
+            github: 'vinisalazar',
+            contribution: ['author'], // List of contribution types ('author', 'maintainer' or 'contributor')
+            orcid: '0000-0002-8362-3195'
         ],
     ]
     homePage        = 'https://github.com/nf-core/funcprofiler'

--- a/nextflow.config
+++ b/nextflow.config
@@ -36,7 +36,7 @@ params {
     help_full                    = false
     show_hidden                  = false
     version                      = false
-    pipelines_testdata_base_path = 'https://raw.githubusercontent.com/vinisalazar/test-datasets/refs/heads/taxprofiler/' // I don't care about what fork we use, but we should probably decide whether to have the refs/heads/taxprofiler/ suffix or not (can replace by funcprofiler later)
+    pipelines_testdata_base_path = 'https://raw.githubusercontent.com/nickp60/test-datasets/refs/heads/funcprofiler/'
     modules_testdata_base_path   = 'https://raw.githubusercontent.com/nf-core/test-datasets/modules/data/'
     trace_report_suffix          = new java.util.Date().format( 'yyyy-MM-dd_HH-mm-ss')
     

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -240,7 +240,7 @@
                     "type": "string",
                     "fa_icon": "far fa-check-circle",
                     "description": "Base URL or local path to location of pipeline test dataset files",
-                    "default": "https://raw.githubusercontent.com/nf-core/test-datasets/",
+                    "default": "https://raw.githubusercontent.com/nf-core/test-datasets/refs/head/taxprofiler/",
                     "hidden": true
                 },
                 "trace_report_suffix": {

--- a/subworkflows/local/longread_adapterremoval.nf
+++ b/subworkflows/local/longread_adapterremoval.nf
@@ -1,0 +1,36 @@
+//
+// Process long raw reads with porechop or porechop_abi
+//
+
+include { PORECHOP_PORECHOP } from '../../modules/nf-core/porechop/porechop/main'
+include { PORECHOP_ABI      } from '../../modules/nf-core/porechop/abi/main'
+
+workflow LONGREAD_ADAPTERREMOVAL {
+    take:
+    reads
+
+    main:
+    ch_versions = Channel.empty()
+    ch_multiqc_files = Channel.empty()
+
+    if (params.longread_adapterremoval_tool == 'porechop_abi') {
+        PORECHOP_ABI(reads)
+        ch_processed_reads = PORECHOP_ABI.out.reads.map { meta, chopped_reads -> [meta + [single_end: true], chopped_reads] }
+        ch_versions = ch_versions.mix(PORECHOP_ABI.out.versions.first())
+        ch_multiqc_files = ch_multiqc_files.mix(PORECHOP_ABI.out.log)
+    }
+    else if (params.longread_adapterremoval_tool == 'porechop') {
+        PORECHOP_PORECHOP(reads)
+        ch_processed_reads = PORECHOP_PORECHOP.out.reads.map { meta, chopped_reads -> [meta + [single_end: true], chopped_reads] }
+        ch_versions = ch_versions.mix(PORECHOP_PORECHOP.out.versions.first())
+        ch_multiqc_files = ch_multiqc_files.mix(PORECHOP_PORECHOP.out.log)
+    }
+    else {
+        ch_processed_reads = reads
+    }
+
+    emit:
+    reads    = ch_processed_reads // channel: [ val(meta), [ reads ] ]
+    versions = ch_versions // channel: [ versions.yml ]
+    mqc      = ch_multiqc_files
+}

--- a/subworkflows/local/longread_filtering.nf
+++ b/subworkflows/local/longread_filtering.nf
@@ -1,0 +1,35 @@
+//
+// Perform filtering
+//
+
+include { FILTLONG } from '../../modules/nf-core/filtlong/main'
+include { NANOQ    } from '../../modules/nf-core/nanoq/main'
+
+workflow LONGREAD_FILTERING {
+    take:
+    reads // [ [ meta ], [ reads ] ]
+
+    main:
+    ch_versions = Channel.empty()
+    ch_multiqc_files = Channel.empty()
+
+    // fastp complexity filtering is activated via modules.conf in shortread_preprocessing
+    if (params.longread_filter_tool == 'filtlong') {
+        ch_filtered_reads = FILTLONG(reads.map { meta, long_reads -> [meta, [], long_reads] }).reads
+        ch_versions = ch_versions.mix(FILTLONG.out.versions.first())
+        ch_multiqc_files = ch_multiqc_files.mix(FILTLONG.out.log)
+    }
+    else if (params.longread_filter_tool == 'nanoq') {
+        ch_filtered_reads = NANOQ(reads, 'fastq.gz').reads
+        ch_versions = ch_versions.mix(NANOQ.out.versions.first())
+        ch_multiqc_files = ch_multiqc_files.mix(NANOQ.out.stats)
+    }
+    else {
+        ch_filtered_reads = reads
+    }
+
+    emit:
+    reads    = ch_filtered_reads // channel: [ val(meta), [ reads ] ]
+    versions = ch_versions // channel: [ versions.yml ]
+    mqc      = ch_multiqc_files
+}

--- a/subworkflows/local/longread_hostremoval.nf
+++ b/subworkflows/local/longread_hostremoval.nf
@@ -1,0 +1,58 @@
+//
+// Remove host reads via alignment and export off-target reads
+//
+
+include { MINIMAP2_INDEX } from '../../modules/nf-core/minimap2/index/main'
+include { MINIMAP2_ALIGN } from '../../modules/nf-core/minimap2/align/main'
+include { SAMTOOLS_VIEW  } from '../../modules/nf-core/samtools/view/main'
+include { SAMTOOLS_FASTQ } from '../../modules/nf-core/samtools/fastq/main'
+include { SAMTOOLS_INDEX } from '../../modules/nf-core/samtools/index/main'
+include { SAMTOOLS_STATS } from '../../modules/nf-core/samtools/stats/main'
+
+workflow LONGREAD_HOSTREMOVAL {
+    take:
+    reads     // [ [ meta ], [ reads ] ]
+    reference // /path/to/fasta
+    index     // /path/to/index
+
+    main:
+    ch_versions = Channel.empty()
+    ch_multiqc_files = Channel.empty()
+
+    if (!params.longread_hostremoval_index) {
+        ch_minimap2_index = MINIMAP2_INDEX([[], reference]).index
+        ch_versions = ch_versions.mix(MINIMAP2_INDEX.out.versions)
+    }
+    else {
+        ch_minimap2_index = index
+    }
+
+    MINIMAP2_ALIGN(reads, ch_minimap2_index, true, 'bai', false, false)
+    ch_versions = ch_versions.mix(MINIMAP2_ALIGN.out.versions.first())
+    ch_minimap2_mapped = MINIMAP2_ALIGN.out.bam.map { meta, long_reads ->
+        [meta, long_reads, []]
+    }
+
+    // Generate unmapped reads FASTQ for downstream taxprofiling
+    SAMTOOLS_VIEW(ch_minimap2_mapped, [[], []], [])
+    ch_versions = ch_versions.mix(SAMTOOLS_VIEW.out.versions.first())
+
+    SAMTOOLS_FASTQ(SAMTOOLS_VIEW.out.bam, false)
+    ch_versions = ch_versions.mix(SAMTOOLS_FASTQ.out.versions.first())
+
+    // Indexing whole BAM for host removal statistics
+    SAMTOOLS_INDEX(MINIMAP2_ALIGN.out.bam)
+    ch_versions = ch_versions.mix(SAMTOOLS_INDEX.out.versions.first())
+
+    bam_bai = MINIMAP2_ALIGN.out.bam.join(SAMTOOLS_INDEX.out.bai)
+
+    SAMTOOLS_STATS(bam_bai, [[], reference])
+    ch_versions = ch_versions.mix(SAMTOOLS_STATS.out.versions.first())
+    ch_multiqc_files = ch_multiqc_files.mix(SAMTOOLS_STATS.out.stats)
+
+    emit:
+    stats    = SAMTOOLS_STATS.out.stats //channel: [val(meta), [reads  ] ]
+    reads    = SAMTOOLS_FASTQ.out.other // channel: [ val(meta), [ reads ] ]
+    versions = ch_versions // channel: [ versions.yml ]
+    mqc      = ch_multiqc_files
+}

--- a/subworkflows/local/longread_preprocessing.nf
+++ b/subworkflows/local/longread_preprocessing.nf
@@ -2,19 +2,56 @@
 // Perform read trimming and filtering
 //
 
+include { FASTQC as FASTQC_PROCESSED } from '../../modules/nf-core/fastqc/main'
+include { FALCO as FALCO_PROCESSED   } from '../../modules/nf-core/falco/main'
+
+include { LONGREAD_ADAPTERREMOVAL    } from './longread_adapterremoval.nf'
+include { LONGREAD_FILTERING         } from './longread_filtering.nf'
 
 workflow LONGREAD_PREPROCESSING {
     take:
     reads
 
     main:
-    ch_versions      = Channel.empty()
-    ch_multiqc_files = Channel.empty()
+    ch_versions = channel.empty()
+    ch_multiqc_files = channel.empty()
 
-    ch_processed_reads = reads
+    if (!params.longread_qc_skipadaptertrim && params.longread_qc_skipqualityfilter) {
+        LONGREAD_ADAPTERREMOVAL(reads)
+        ch_processed_reads = LONGREAD_ADAPTERREMOVAL.out.reads
+        ch_versions = ch_versions.mix(LONGREAD_ADAPTERREMOVAL.out.versions.first())
+        ch_multiqc_files = ch_multiqc_files.mix(LONGREAD_ADAPTERREMOVAL.out.mqc)
+    }
+    else if (params.longread_qc_skipadaptertrim && !params.longread_qc_skipqualityfilter) {
+        LONGREAD_FILTERING(reads)
+        ch_processed_reads = LONGREAD_FILTERING.out.reads
+        ch_versions = ch_versions.mix(LONGREAD_FILTERING.out.versions.first())
+        ch_multiqc_files = ch_multiqc_files.mix(LONGREAD_FILTERING.out.mqc)
+    }
+    else {
+        LONGREAD_ADAPTERREMOVAL(reads)
+        ch_clipped_reads = LONGREAD_ADAPTERREMOVAL.out.reads.map { meta, clipped_long_reads -> [meta + [single_end: true], clipped_long_reads] }
+        LONGREAD_FILTERING(ch_clipped_reads)
+        ch_processed_reads = LONGREAD_FILTERING.out.reads
+        ch_versions = ch_versions.mix(LONGREAD_ADAPTERREMOVAL.out.versions.first())
+        ch_versions = ch_versions.mix(LONGREAD_FILTERING.out.versions.first())
+        ch_multiqc_files = ch_multiqc_files.mix(LONGREAD_ADAPTERREMOVAL.out.mqc)
+        ch_multiqc_files = ch_multiqc_files.mix(LONGREAD_FILTERING.out.mqc)
+    }
+
+    if (params.preprocessing_qc_tool == 'fastqc') {
+        FASTQC_PROCESSED(ch_processed_reads)
+        ch_versions = ch_versions.mix(FASTQC_PROCESSED.out.versions)
+        ch_multiqc_files = ch_multiqc_files.mix(FASTQC_PROCESSED.out.zip)
+    }
+    else if (params.preprocessing_qc_tool == 'falco') {
+        FALCO_PROCESSED(ch_processed_reads)
+        ch_versions = ch_versions.mix(FALCO_PROCESSED.out.versions)
+        ch_multiqc_files = ch_multiqc_files.mix(FALCO_PROCESSED.out.txt)
+    }
 
     emit:
-    reads    = ch_processed_reads   // channel: [ val(meta), [ reads ] ]
-    versions = ch_versions          // channel: [ versions.yml ]
+    reads    = ch_processed_reads // channel: [ val(meta), [ reads ] ]
+    versions = ch_versions // channel: [ versions.yml ]
     mqc      = ch_multiqc_files
 }

--- a/subworkflows/local/shortread_adapterremoval.nf
+++ b/subworkflows/local/shortread_adapterremoval.nf
@@ -1,0 +1,87 @@
+//
+// Process short raw reads with AdapterRemoval
+//
+
+include { ADAPTERREMOVAL as ADAPTERREMOVAL_SINGLE } from '../../modules/nf-core/adapterremoval/main'
+include { ADAPTERREMOVAL as ADAPTERREMOVAL_PAIRED } from '../../modules/nf-core/adapterremoval/main'
+include { CAT_FASTQ                               } from '../../modules/nf-core/cat/fastq/main'
+
+workflow SHORTREAD_ADAPTERREMOVAL {
+    take:
+    reads       // [[meta], [reads]]
+    adapterlist // file
+
+    main:
+    ch_versions = Channel.empty()
+    ch_multiqc_files = Channel.empty()
+
+    ch_input_for_adapterremoval = reads.branch {
+        single: it[0].single_end
+        paired: !it[0].single_end
+    }
+
+    ADAPTERREMOVAL_SINGLE(ch_input_for_adapterremoval.single, adapterlist)
+    ADAPTERREMOVAL_PAIRED(ch_input_for_adapterremoval.paired, adapterlist)
+
+    /*
+     * Due to the ~slightly~ very ugly output implementation of the current AdapterRemoval2 version, each file
+     * has to be exported in a separate channel and we must manually recombine when necessary.
+     */
+
+    if (params.shortread_qc_mergepairs && params.shortread_qc_includeunmerged) {
+
+        ch_concat_fastq = Channel.empty()
+            .mix(
+                ADAPTERREMOVAL_PAIRED.out.collapsed,
+                ADAPTERREMOVAL_PAIRED.out.collapsed_truncated,
+                ADAPTERREMOVAL_PAIRED.out.singles_truncated,
+                ADAPTERREMOVAL_PAIRED.out.paired_truncated,
+            )
+            .map { meta, adapterremoved_reads ->
+                [meta + [single_end: true], adapterremoved_reads]
+            }
+            .groupTuple()
+            .map { meta, fastq -> [meta, fastq.flatten()] }
+        // Paired-end reads cause a nested tuple during grouping.
+        // We want to present a flat list of files to `CAT_FASTQ`, thus the flatten
+
+        CAT_FASTQ(ch_concat_fastq)
+
+        ch_adapterremoval_reads_prepped = CAT_FASTQ.out.reads.mix(ADAPTERREMOVAL_SINGLE.out.singles_truncated)
+    }
+    else if (params.shortread_qc_mergepairs && !params.shortread_qc_includeunmerged) {
+
+        ch_concat_fastq = Channel.empty()
+            .mix(
+                ADAPTERREMOVAL_PAIRED.out.collapsed,
+                ADAPTERREMOVAL_PAIRED.out.collapsed_truncated,
+            )
+            .map { meta, input_reads ->
+                [meta + [single_end: true], input_reads]
+            }
+            .groupTuple()
+            .map { meta, fastq -> [meta, fastq.flatten()] }
+
+
+        CAT_FASTQ(ch_concat_fastq)
+
+        ch_adapterremoval_reads_prepped = CAT_FASTQ.out.reads.mix(ADAPTERREMOVAL_SINGLE.out.singles_truncated)
+    }
+    else {
+
+        ch_adapterremoval_reads_prepped = ADAPTERREMOVAL_PAIRED.out.paired_truncated.mix(ADAPTERREMOVAL_SINGLE.out.singles_truncated)
+    }
+
+    ch_versions = ch_versions.mix(ADAPTERREMOVAL_SINGLE.out.versions.first())
+    ch_versions = ch_versions.mix(ADAPTERREMOVAL_PAIRED.out.versions.first())
+
+    ch_multiqc_files = ch_multiqc_files.mix(
+        ADAPTERREMOVAL_PAIRED.out.settings,
+        ADAPTERREMOVAL_SINGLE.out.settings,
+    )
+
+    emit:
+    reads    = ch_adapterremoval_reads_prepped // channel: [ val(meta), [ reads ] ]
+    versions = ch_versions // channel: [ versions.yml ]
+    mqc      = ch_multiqc_files
+}

--- a/subworkflows/local/shortread_complexityfiltering.nf
+++ b/subworkflows/local/shortread_complexityfiltering.nf
@@ -1,0 +1,34 @@
+//
+// Check input samplesheet and get read channels
+//
+
+include { BBMAP_BBDUK     } from '../../modules/nf-core/bbmap/bbduk/main'
+include { PRINSEQPLUSPLUS } from '../../modules/nf-core/prinseqplusplus/main'
+
+workflow SHORTREAD_COMPLEXITYFILTERING {
+    take:
+    reads // [ [ meta ], [ reads ] ]
+
+    main:
+    ch_versions = Channel.empty()
+    ch_multiqc_files = Channel.empty()
+
+    // fastp complexity filtering is activated via modules.conf in shortread_preprocessing
+    if (params.shortread_complexityfilter_tool == 'bbduk') {
+        ch_filtered_reads = BBMAP_BBDUK(reads, []).reads
+        ch_versions = ch_versions.mix(BBMAP_BBDUK.out.versions.first())
+        ch_multiqc_files = ch_multiqc_files.mix(BBMAP_BBDUK.out.log)
+    }
+    else if (params.shortread_complexityfilter_tool == 'prinseqplusplus') {
+        ch_filtered_reads = PRINSEQPLUSPLUS(reads).good_reads
+        ch_versions = ch_versions.mix(PRINSEQPLUSPLUS.out.versions.first())
+    }
+    else {
+        ch_filtered_reads = reads
+    }
+
+    emit:
+    reads    = ch_filtered_reads // channel: [ val(meta), [ reads ] ]
+    versions = ch_versions // channel: [ versions.yml ]
+    mqc      = ch_multiqc_files
+}

--- a/subworkflows/local/shortread_fastp.nf
+++ b/subworkflows/local/shortread_fastp.nf
@@ -1,0 +1,49 @@
+//
+// Process short raw reads with FastP
+//
+
+include { FASTP as FASTP_SINGLE } from '../../modules/nf-core/fastp/main'
+include { FASTP as FASTP_PAIRED } from '../../modules/nf-core/fastp/main'
+
+workflow SHORTREAD_FASTP {
+    take:
+    reads       // [[meta], [reads]]
+    adapterlist
+
+    main:
+    ch_versions = Channel.empty()
+    ch_multiqc_files = Channel.empty()
+
+    ch_input_for_fastp = reads.branch {
+        single: it[0]['single_end'] == true
+        paired: it[0]['single_end'] == false
+    }
+
+    FASTP_SINGLE(ch_input_for_fastp.single, adapterlist, false, false, false)
+    // Last parameter here turns on merging of PE data
+    FASTP_PAIRED(ch_input_for_fastp.paired, adapterlist, false, false, params.shortread_qc_mergepairs)
+
+    if (params.shortread_qc_mergepairs) {
+        ch_fastp_reads_prepped_pe = FASTP_PAIRED.out.reads_merged.map { meta, merged_reads ->
+            [meta + [single_end: true], [merged_reads].flatten()]
+        }
+
+        ch_fastp_reads_prepped = ch_fastp_reads_prepped_pe.mix(FASTP_SINGLE.out.reads)
+    }
+    else {
+        ch_fastp_reads_prepped = FASTP_PAIRED.out.reads.mix(FASTP_SINGLE.out.reads)
+    }
+
+    ch_versions = ch_versions.mix(FASTP_SINGLE.out.versions.first())
+    ch_versions = ch_versions.mix(FASTP_PAIRED.out.versions.first())
+
+    ch_processed_reads = ch_fastp_reads_prepped
+
+    ch_multiqc_files = ch_multiqc_files.mix(FASTP_SINGLE.out.json)
+    ch_multiqc_files = ch_multiqc_files.mix(FASTP_PAIRED.out.json)
+
+    emit:
+    reads    = ch_processed_reads // channel: [ val(meta), [ reads ] ]
+    versions = ch_versions // channel: [ versions.yml ]
+    mqc      = ch_multiqc_files
+}

--- a/subworkflows/local/shortread_hostremoval.nf
+++ b/subworkflows/local/shortread_hostremoval.nf
@@ -1,0 +1,48 @@
+//
+// Remove host reads via alignment and export off-target reads
+//
+
+include { BOWTIE2_BUILD  } from '../../modules/nf-core/bowtie2/build/main'
+include { BOWTIE2_ALIGN  } from '../../modules/nf-core/bowtie2/align/main'
+include { SAMTOOLS_INDEX } from '../../modules/nf-core/samtools/index/main'
+include { SAMTOOLS_STATS } from '../../modules/nf-core/samtools/stats/main'
+
+workflow SHORTREAD_HOSTREMOVAL {
+    take:
+    reads     // [ [ meta ], [ reads ] ]
+    reference // /path/to/fasta
+    index     // /path/to/index
+
+    main:
+    ch_versions = Channel.empty()
+    ch_multiqc_files = Channel.empty()
+
+    if (!params.shortread_hostremoval_index) {
+        ch_bowtie2_index = BOWTIE2_BUILD([[], reference]).index
+        ch_versions = ch_versions.mix(BOWTIE2_BUILD.out.versions)
+    }
+    else {
+        ch_bowtie2_index = index.first()
+    }
+
+    // Map, generate BAM with all reads and unmapped reads in FASTQ for downstream
+    BOWTIE2_ALIGN(reads, ch_bowtie2_index, [[], reference], true, true)
+    ch_versions = ch_versions.mix(BOWTIE2_ALIGN.out.versions.first())
+    ch_multiqc_files = ch_multiqc_files.mix(BOWTIE2_ALIGN.out.log)
+
+    // Indexing whole BAM for host removal statistics
+    SAMTOOLS_INDEX(BOWTIE2_ALIGN.out.bam)
+    ch_versions = ch_versions.mix(SAMTOOLS_INDEX.out.versions.first())
+
+    bam_bai = BOWTIE2_ALIGN.out.bam.join(SAMTOOLS_INDEX.out.bai, remainder: true)
+
+    SAMTOOLS_STATS(bam_bai, [[], reference])
+    ch_versions = ch_versions.mix(SAMTOOLS_STATS.out.versions.first())
+    ch_multiqc_files = ch_multiqc_files.mix(SAMTOOLS_STATS.out.stats)
+
+    emit:
+    stats    = SAMTOOLS_STATS.out.stats
+    reads    = BOWTIE2_ALIGN.out.fastq // channel: [ val(meta), [ reads ] ]
+    versions = ch_versions // channel: [ versions.yml ]
+    mqc      = ch_multiqc_files
+}

--- a/subworkflows/local/shortread_preprocessing.nf
+++ b/subworkflows/local/shortread_preprocessing.nf
@@ -3,6 +3,10 @@
 //
 
 
+include { SHORTREAD_FASTP            } from './shortread_fastp'
+include { SHORTREAD_ADAPTERREMOVAL   } from './shortread_adapterremoval'
+include { FASTQC as FASTQC_PROCESSED } from '../../modules/nf-core/fastqc/main'
+include { FALCO as FALCO_PROCESSED   } from '../../modules/nf-core/falco/main'
 
 workflow SHORTREAD_PREPROCESSING {
     take:
@@ -10,14 +14,38 @@ workflow SHORTREAD_PREPROCESSING {
     adapterlist // file
 
     main:
-    ch_versions       = Channel.empty()
-    ch_multiqc_files  = Channel.empty()
+    ch_versions = channel.empty()
+    ch_multiqc_files = channel.empty()
 
-    ch_processed_reads = reads
+    if (params.shortread_qc_tool == "fastp") {
+        SHORTREAD_FASTP(reads, adapterlist)
+        ch_processed_reads = SHORTREAD_FASTP.out.reads
+        ch_versions = ch_versions.mix(SHORTREAD_FASTP.out.versions)
+        ch_multiqc_files = ch_multiqc_files.mix(SHORTREAD_FASTP.out.mqc)
+    }
+    else if (params.shortread_qc_tool == "adapterremoval") {
+        SHORTREAD_ADAPTERREMOVAL(reads, adapterlist)
+        ch_processed_reads = SHORTREAD_ADAPTERREMOVAL.out.reads
+        ch_versions = ch_versions.mix(SHORTREAD_ADAPTERREMOVAL.out.versions)
+        ch_multiqc_files = ch_multiqc_files.mix(SHORTREAD_ADAPTERREMOVAL.out.mqc)
+    }
+    else {
+        ch_processed_reads = reads
+    }
 
+    if (params.preprocessing_qc_tool == 'fastqc') {
+        FASTQC_PROCESSED(ch_processed_reads)
+        ch_versions = ch_versions.mix(FASTQC_PROCESSED.out.versions)
+        ch_multiqc_files = ch_multiqc_files.mix(FASTQC_PROCESSED.out.zip)
+    }
+    else if (params.preprocessing_qc_tool == 'falco') {
+        FALCO_PROCESSED(ch_processed_reads)
+        ch_versions = ch_versions.mix(FALCO_PROCESSED.out.versions)
+        ch_multiqc_files = ch_multiqc_files.mix(FALCO_PROCESSED.out.txt)
+    }
 
     emit:
-    reads    = ch_processed_reads   // channel: [ val(meta), [ reads ] ]
-    versions = ch_versions          // channel: [ versions.yml ]
+    reads    = ch_processed_reads // channel: [ val(meta), [ reads ] ]
+    versions = ch_versions // channel: [ versions.yml ]
     mqc      = ch_multiqc_files
 }

--- a/tests/default.nf.test
+++ b/tests/default.nf.test
@@ -25,9 +25,9 @@ nextflow_pipeline {
                     // pipeline versions.yml file for multiqc from which Nextflow version is removed because we test pipelines on multiple Nextflow versions
                     removeNextflowVersion("$outputDir/pipeline_info/nf_core_funcprofiler_software_mqc_versions.yml"),
                     // All stable path name, with a relative path
-                    stable_name,
+                    // stable_name,
                     // All files with stable contents
-                    stable_path
+                    // stable_path
                 ).match() }
             )
         }

--- a/tests/default.nf.test.snap
+++ b/tests/default.nf.test.snap
@@ -1,0 +1,65 @@
+{
+    "-profile test": {
+        "content": [
+            12,
+            null,
+            [
+                "fastp",
+                "fastp/2612.fastp.fastq.gz",
+                "fastp/2612.fastp.html",
+                "fastp/2612.fastp.json",
+                "fastp/2612.fastp.log",
+                "fastp/2612.merged.fastq.gz",
+                "fastp/2612_1.fastp.fastq.gz",
+                "fastp/2612_2.fastp.fastq.gz",
+                "fastp/2613.fastp.html",
+                "fastp/2613.fastp.json",
+                "fastp/2613.fastp.log",
+                "fastp/2613.merged.fastq.gz",
+                "fastp/2613_1.fastp.fastq.gz",
+                "fastp/2613_2.fastp.fastq.gz",
+                "fastqc",
+                "fastqc/2612_fastqc.html",
+                "fastqc/2612_fastqc.zip",
+                "fastqc/2613_fastqc.html",
+                "fastqc/2613_fastqc.zip",
+                "fastqc/ERR3201952_fastqc.html",
+                "fastqc/ERR3201952_fastqc.zip",
+                "merge",
+                "merge/2612.merged.fastq.gz",
+                "nanoq",
+                "nanoq/ERR3201952_filtered.fastq.gz",
+                "nanoq/ERR3201952_filtered.stats",
+                "pipeline_info",
+                "porechop",
+                "porechop/ERR3201952.porechop_abi.fastq.gz",
+                "porechop/ERR3201952.porechop_abi.log"
+            ],
+            [
+                "2612.fastp.fastq.gz:md5,b4f19489c85871f4e4888dd092538a41",
+                "2612.fastp.html:md5,bb508efda757c43300bb9393994d8ec7",
+                "2612.fastp.json:md5,dac3532e723b8b5ed5ca1625ad2102d3",
+                "2612.fastp.log:md5,610eabb31067b24c525b234fe8552254",
+                "2612.merged.fastq.gz:md5,7f774191ba98093c716f35caadeee96c",
+                "2612_1.fastp.fastq.gz:md5,8ec57f802a411560eb202cfdd58a4477",
+                "2612_2.fastp.fastq.gz:md5,3665edf43991c3172d6cf1412ca93cb5",
+                "2613.fastp.html:md5,229152775ab5c452d27d5b48ec6eeff4",
+                "2613.fastp.json:md5,5aab1cc94c8ee3dfa8b1321cb561f343",
+                "2613.fastp.log:md5,183b286ad901129fb5d2d3e4240ad0b9",
+                "2613.merged.fastq.gz:md5,67c4448f55d7feab0eb4ebb888dc6c02",
+                "2613_1.fastp.fastq.gz:md5,6e76738f37ff535f3e43dfdc5307bb06",
+                "2613_2.fastp.fastq.gz:md5,f6c9f7eff7d9cb72a05401833f565bac",
+                "2612.merged.fastq.gz:md5,8d1a3760617a21698535f19a036e7544",
+                "ERR3201952_filtered.fastq.gz:md5,ef878d091d7e9b60684f11b0f04fd250",
+                "ERR3201952_filtered.stats:md5,07a6e27538e023cc468b93b26147b78c",
+                "ERR3201952.porechop_abi.fastq.gz:md5,ef878d091d7e9b60684f11b0f04fd250",
+                "ERR3201952.porechop_abi.log:md5,256aa2fb5bf99100154b77caf2a7dee1"
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "25.10.3"
+        },
+        "timestamp": "2026-02-13T14:26:38.814026"
+    }
+}

--- a/workflows/funcprofiler.nf
+++ b/workflows/funcprofiler.nf
@@ -79,6 +79,24 @@ workflow FUNCPROFILER {
     ch_versions = Channel.empty()
     ch_multiqc_files = Channel.empty()
 
+    // Preprocessing auxiliary file input channel preperation
+    adapterlist = params.shortread_qc_adapterlist ? file(params.shortread_qc_adapterlist) : []
+    if (params.hostremoval_reference) {
+        ch_reference = file(params.hostremoval_reference)
+    }
+    if (params.shortread_hostremoval_index) {
+        ch_shortread_reference_index = channel.fromPath(params.shortread_hostremoval_index).map { [[], it] }
+    }
+    else {
+        ch_shortread_reference_index = []
+    }
+    if (params.longread_hostremoval_index) {
+        ch_longread_reference_index = file(params.longread_hostremoval_index)
+    }
+    else {
+        ch_longread_reference_index = []
+    }
+
    // Validate input files and create separate channels for FASTQ, FASTA, and Nanopore data
     ch_input = samplesheet
         .map { meta, run_accession, instrument_platform, fastq_1, fastq_2, fasta ->


### PR DESCRIPTION
This PR adds modules and subworkflows used in taxprofiler, for short- and long-reads preprocessing and QC.