### PR TITLE
Improve humann tests

### DIFF
--- a/modules/local/humann/humann/tests/main.nf.test
+++ b/modules/local/humann/humann/tests/main.nf.test
@@ -25,7 +25,7 @@ nextflow_process {
                 """
                 input[0] = Channel.of([
                     [],
-                    file( '/Users/nwaters/GitHub/test-datasets/data/database/humann/v3/chocophlan_nfDEMO.tar.gz', checkIfExists: true )
+                    file( 'https://raw.githubusercontent.com/nickp60/test-datasets/refs/heads/funcprofiler/data/database/humann/v3/chocophlan_nfDEMO.tar.gz', checkIfExists: true )
                 ])
                 """
             }
@@ -36,7 +36,7 @@ nextflow_process {
                 """
                 input[0] = Channel.of([
                     [],
-                    file( '/Users/nwaters/GitHub/test-datasets/data/database/humann/v3/uniref_nfDEMO.tar.gz', checkIfExists: true )
+                    file( 'https://raw.githubusercontent.com/nickp60/test-datasets/refs/heads/funcprofiler/data/database/humann/v3/uniref_nfDEMO.tar.gz', checkIfExists: true )
                 ])
                 """
             }
@@ -47,7 +47,7 @@ nextflow_process {
                 """
                 input[0] = Channel.of([
                     [],
-                    file( '/Users/nwaters/GitHub/test-datasets/data/database/humann/v3/utility_nfDEMO.tar.gz', checkIfExists: true )
+                    file( 'https://raw.githubusercontent.com/nickp60/test-datasets/refs/heads/funcprofiler/data/database/humann/v3/utility_nfDEMO.tar.gz', checkIfExists: true )
                 ])
                 """
             }

--- a/modules/local/humann/humann/tests/main.nf.test
+++ b/modules/local/humann/humann/tests/main.nf.test
@@ -85,7 +85,7 @@ nextflow_process {
         then {
             assertAll(
                 { assert process.success },
-                { assert snapshot(process.out).match() }
+                { assert snapshot(process.out.genefamilies, process.out.pathabundance, process.out.pathcoverage, process.out.reactions).match() }
             )
         }
 

--- a/modules/local/humann/humann/tests/main.nf.test.snap
+++ b/modules/local/humann/humann/tests/main.nf.test.snap
@@ -1,97 +1,41 @@
 {
     "humann_v3 sarscov2 - fastq": {
         "content": [
-            {
-                "0": [
-                    [
-                        {
-                            "id": "test",
-                            "single_end": true
-                        },
-                        "test_genefamilies.tsv.gz:md5,b9777e24dd24e1257eb6906aba5463f5"
-                    ]
-                ],
-                "1": [
-                    [
-                        {
-                            "id": "test",
-                            "single_end": true
-                        },
-                        "test_pathabundance.tsv.gz:md5,65f73f474bdb2a7c8b278766ca789a3c"
-                    ]
-                ],
-                "2": [
-                    [
-                        {
-                            "id": "test",
-                            "single_end": true
-                        },
-                        "test_pathcoverage.tsv.gz:md5,17c91a2581f34b55179aa4c79c242b1c"
-                    ]
-                ],
-                "3": [
-                    
-                ],
-                "4": [
-                    [
-                        {
-                            "id": "test",
-                            "single_end": true
-                        },
-                        "test.log:md5,bec1de946440d6556045a33e04259a83"
-                    ]
-                ],
-                "5": [
-                    "versions.yml:md5,103f216970b211a5eac91936ef8a93ac"
-                ],
-                "genefamilies": [
-                    [
-                        {
-                            "id": "test",
-                            "single_end": true
-                        },
-                        "test_genefamilies.tsv.gz:md5,b9777e24dd24e1257eb6906aba5463f5"
-                    ]
-                ],
-                "log": [
-                    [
-                        {
-                            "id": "test",
-                            "single_end": true
-                        },
-                        "test.log:md5,bec1de946440d6556045a33e04259a83"
-                    ]
-                ],
-                "pathabundance": [
-                    [
-                        {
-                            "id": "test",
-                            "single_end": true
-                        },
-                        "test_pathabundance.tsv.gz:md5,65f73f474bdb2a7c8b278766ca789a3c"
-                    ]
-                ],
-                "pathcoverage": [
-                    [
-                        {
-                            "id": "test",
-                            "single_end": true
-                        },
-                        "test_pathcoverage.tsv.gz:md5,17c91a2581f34b55179aa4c79c242b1c"
-                    ]
-                ],
-                "reactions": [
-                    
-                ],
-                "versions": [
-                    "versions.yml:md5,103f216970b211a5eac91936ef8a93ac"
+            [
+                [
+                    {
+                        "id": "test",
+                        "single_end": true
+                    },
+                    "test_genefamilies.tsv.gz:md5,b9777e24dd24e1257eb6906aba5463f5"
                 ]
-            }
+            ],
+            [
+                [
+                    {
+                        "id": "test",
+                        "single_end": true
+                    },
+                    "test_pathabundance.tsv.gz:md5,65f73f474bdb2a7c8b278766ca789a3c"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "test",
+                        "single_end": true
+                    },
+                    "test_pathcoverage.tsv.gz:md5,17c91a2581f34b55179aa4c79c242b1c"
+                ]
+            ],
+            [
+                
+            ]
         ],
+        "timestamp": "2026-02-26T16:15:51.510722226",
         "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "25.04.7"
-        },
-        "timestamp": "2026-02-23T15:11:31.153359"
+            "nf-test": "0.9.4",
+            "nextflow": "25.10.4"
+        }
     }
 }

--- a/modules/local/humann/humann/tests/main_v4.nf.test
+++ b/modules/local/humann/humann/tests/main_v4.nf.test
@@ -25,7 +25,7 @@ nextflow_process {
                 """
                 input[0] = Channel.of([
                     [],
-                    file( '/Users/nwaters/GitHub/test-datasets/data/database/humann/v4/chocophlan_nfDEMO.tar.gz', checkIfExists: true )
+                    file( 'https://raw.githubusercontent.com/nickp60/test-datasets/refs/heads/funcprofiler/data/database/humann/v4/chocophlan_nfDEMO.tar.gz', checkIfExists: true )
                 ])
                 """
             }
@@ -36,7 +36,7 @@ nextflow_process {
                 """
                 input[0] = Channel.of([
                     [],
-                    file( '/Users/nwaters/GitHub/test-datasets/data/database/humann/v4/uniref_nfDEMO.tar.gz', checkIfExists: true )
+                    file( 'https://raw.githubusercontent.com/nickp60/test-datasets/refs/heads/funcprofiler/data/database/humann/v4/uniref_nfDEMO.tar.gz', checkIfExists: true )
                 ])
                 """
             }
@@ -47,7 +47,7 @@ nextflow_process {
                 """
                 input[0] = Channel.of([
                     [],
-                    file( '/Users/nwaters/GitHub/test-datasets/data/database/humann/v4/utility_nfDEMO.tar.gz', checkIfExists: true )
+                    file( 'https://raw.githubusercontent.com/nickp60/test-datasets/refs/heads/funcprofiler/data/database/humann/v4/utility_nfDEMO.tar.gz', checkIfExists: true )
                 ])
                 """
             }

--- a/modules/local/humann/humann/tests/main_v4.nf.test
+++ b/modules/local/humann/humann/tests/main_v4.nf.test
@@ -6,7 +6,7 @@ nextflow_process {
     tag "modules"
     tag "modules_"
     tag "humann"
-    config "./nextflow.config"
+
     setup{
         run("UNTAR") {
             script "modules/nf-core/untar/main.nf"
@@ -94,10 +94,10 @@ nextflow_process {
         }
 
         then {
-            def stable_name = getAllFilesFromDir(params.outdir, relative: true, includeDir: true, ignore: ['pipeline_info/*.{html,json,txt}', '*.log', 'humann3/*'])
+            def stable_name = getAllFilesFromDir(params.outdir, relative: true, includeDir: true, ignore: ['pipeline_info/*.{html,json,txt}', '**/*.log', '**/*.biom', 'humann3/*'])
 	    println(stable_name)
             // stable_path: All files in ${params.outdir}/ with stable content
-            def stable_path = getAllFilesFromDir(params.outdir, ignoreFile: 'tests/.nftignore')
+            def stable_path = getAllFilesFromDir(params.outdir, ignoreFile: 'tests/.nftignore', ignore: ['**/*.log', '**/*.biom'])
 	    println(stable_path)
             assertAll(
                 { assert workflow.success},

--- a/modules/local/humann/humann/tests/main_v4.nf.test.snap
+++ b/modules/local/humann/humann/tests/main_v4.nf.test.snap
@@ -5,12 +5,10 @@
             null,
             [
                 "humann4",
-                "humann4/test.log",
                 "humann4/test_2_genefamilies.tsv.gz",
                 "humann4/test_3_reactions.tsv.gz",
                 "humann4/test_4_pathabundance.tsv.gz",
                 "mpa",
-                "mpa/test.biom",
                 "mpa/test.bowtie2out.txt",
                 "mpa/test_profile.txt",
                 "pipeline_info",
@@ -52,11 +50,9 @@
                 "untar/utility_nfDEMO/vOct22_SGB_mapping.tsv"
             ],
             [
-                "test.log:md5,ca548ae470fc0d49df520a0f9104b5cc",
                 "test_2_genefamilies.tsv.gz:md5,34f174a6d642d21bb14af35a6fe9dd69",
                 "test_3_reactions.tsv.gz:md5,c026112aa2b41eb63e3752db315b2515",
                 "test_4_pathabundance.tsv.gz:md5,825a3b76f509e1de6d27d10af6ef885a",
-                "test.biom:md5,c503f30fa402ffe2992eace9f101b1ca",
                 "test.bowtie2out.txt:md5,ef46a9c6a8ce9cae26fbfd5527116fd5",
                 "test_profile.txt:md5,0dac5843d397e7042bf088cf65217f92",
                 "test_mock_profile.txt:md5,c155a9c471a135a1dbd6e9e075f3315c",
@@ -91,10 +87,10 @@
                 "vOct22_SGB_mapping.tsv:md5,a68aa8c70eb85300735848fe396dec09"
             ]
         ],
+        "timestamp": "2026-02-26T16:45:07.078720553",
         "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "25.04.7"
-        },
-        "timestamp": "2026-02-23T15:11:57.211862"
+            "nf-test": "0.9.4",
+            "nextflow": "25.10.4"
+        }
     }
 }


### PR DESCRIPTION
Re: #8 

**Summary of changes:**
- remove .log and .biom files from snapshot checks, as they're not stable
- use GitHub URLs instead of hardcoded paths, this will eventually have to be edited once datasets are in the nf-core/test-datasets repo, but still, it's an improvement for now
- update snapshots