### PR TITLE
docs: populate pipeline tool citations

### DIFF
--- a/CITATIONS.md
+++ b/CITATIONS.md
@@ -14,13 +14,41 @@
 
 > Buchfink B, Reuter K, Drost HG. Sensitive protein alignments at tree-of-life scale using DIAMOND. Nat Methods. 2021 Apr;18(4):366-368. doi: 10.1038/s41592-021-01101-x. PubMed PMID: 33828273.
 
+- [eggNOG-mapper](https://github.com/eggnogdb/eggnog-mapper)
+
+> Cantalapiedra CP, Hernández-Plaza A, Letunic I, Bork P, Huerta-Cepas J. eggNOG-mapper v2: Functional Annotation, Orthology Assignments, and Domain Prediction at the Metagenomic Scale. Mol Biol Evol. 2021 Dec 9;38(12):5825-5829. doi: 10.1093/molbev/msab293. PubMed PMID: 34597405.
+
 - [FastQC](https://www.bioinformatics.babraham.ac.uk/projects/fastqc/)
 
 > Andrews, S. (2010). FastQC: A Quality Control Tool for High Throughput Sequence Data [Online].
 
+- [fmh-funprofiler](https://github.com/KoslickiLab/fmh-funprofiler)
+
+> Hera MR, Liu S, Wei W, Rodriguez JS, Ma C, Koslicki D. Metagenomic functional profiling: to sketch or not to sketch? Bioinformatics. 2024 Sep 1;40(Suppl 2):ii165-ii173. doi: 10.1093/bioinformatics/btae397. PubMed PMID: 39230701.
+
+- [HUMAnN](https://huttenhower.sph.harvard.edu/humann/)
+
+> Beghini F, McIver LJ, Blanco-Míguez A, Dubois L, Asnicar F, Maharjan S, et al. Integrating taxonomic, functional, and strain-level profiling of diverse microbial communities with bioBakery 3. Elife. 2021 May 4;10:e65088. doi: 10.7554/eLife.65088. PubMed PMID: 33944776.
+
+- [MetaPhlAn](https://huttenhower.sph.harvard.edu/metaphlan/)
+
+> Blanco-Míguez A, Beghini F, Cumbo F, McIver LJ, Thompson KN, Zolfo M, et al. Extending and improving metagenomic taxonomic profiling with uncharacterized species using MetaPhlAn 4. Nat Biotechnol. 2023 Nov;41(11):1633-1644. doi: 10.1038/s41587-023-01688-w. Epub 2023 Feb 23. PubMed PMID: 36823356.
+
+- [mi-faser](https://services.bromberglab.org/mifaser/about)
+
+> Zhu C, Miller M, Marpaka S, Vaysberg P, Rühlemann MC, Wu G, et al. Functional sequencing read annotation for high precision microbiome analysis. Nucleic Acids Res. 2018 Feb 28;46(4):e23. doi: 10.1093/nar/gkx1209. PubMed PMID: 29194524.
+
+> Mahlich Y, Zhu C, Chung H, Velaga PK, De Paolis Kaluza MC, Radivojac P, Friedberg I, Bromberg Y. Learning from the unknown: exploring the range of bacterial functionality. Nucleic Acids Res. 2023 Oct 27;51(19):10162-10175. doi: 10.1093/nar/gkad757. PubMed PMID: 37739408.
+
+> Zhu C, Delmont TO, Vogel TM, Bromberg Y. Functional Basis of Microorganism Classification. PLoS Comput Biol. 2015 Aug 28;11(8):e1004472. doi: 10.1371/journal.pcbi.1004472. PubMed PMID: 26317871.
+
 - [MultiQC](https://pubmed.ncbi.nlm.nih.gov/27312411/)
 
 > Ewels P, Magnusson M, Lundin S, Käller M. MultiQC: summarize analysis results for multiple tools and samples in a single report. Bioinformatics. 2016 Oct 1;32(19):3047-8. doi: 10.1093/bioinformatics/btw354. Epub 2016 Jun 16. PubMed PMID: 27312411; PubMed Central PMCID: PMC5039924.
+
+- [RGI / CARD](https://card.mcmaster.ca/)
+
+> Alcock BP, Huynh W, Chalil R, Smith KW, Raphenya AR, Wlodarski MA, et al. CARD 2023: expanded curation, support for machine learning, and resistome prediction at the Comprehensive Antibiotic Resistance Database. Nucleic Acids Res. 2023 Jan 6;51(D1):D690-D699. doi: 10.1093/nar/gkac920. PubMed PMID: 36263822.
 
 ## Software packaging/containerisation tools
 


### PR DESCRIPTION
## Summary

- Retargets the existing contribution to `feat/cite`, as requested by the maintainer.
- Adds the three runtime-attribution publications that are still absent from that branch: eggNOG-mapper v2 and two additional mi-faser-related papers.
- Keeps the delta documentation-only: one file and eight added lines, with no runtime, module, generated-file, or dependency changes.

Closes #61.

## Automated contribution disclosure

This PR was prepared and updated through an automated, AI-assisted workflow. The validation below was machine-executed; no claim of independent human review is made.

## Validation

- Compared `CITATIONS.md` on `feat/cite` with `toolCitationText()` and confirmed that the three added DOIs are the remaining missing runtime references.
- Crossref resolved all three DOIs and returned matching titles, authors, journals, volumes, issues, and pages.
- PubMed returned the three matching records and PMIDs: 34597405, 37739408, and 26317871.
- `npx.cmd --offline --yes prettier@3.8.3 --check <added-lines-only.md>` — passed.
- `git diff --check` — passed.
- The eggNOG-mapper repository link resolves to the active public `eggnogdb/eggnog-mapper` repository.

## Scope note

The full `CITATIONS.md` on the unmodified `feat/cite` baseline already fails Prettier. This update deliberately avoids reformatting unrelated upstream content; the eight added lines pass the same Prettier version in isolation.

## PR checklist

- [x] This description explains the change and its reason.
- [x] The added Markdown and citation metadata passed targeted checks.
- [x] Runtime tests and test-data changes are not applicable to this documentation-only delta.
