### PR TITLE
docs: add remaining tool citations

### DIFF
--- a/CITATIONS.md
+++ b/CITATIONS.md
@@ -18,6 +18,10 @@
 
 > Buchfink B, Xie C, Huson DH. Fast and sensitive protein alignment using DIAMOND. Nat Methods. 2015 Jan;12(1):59-60. doi: 10.1038/nmeth.3176. Epub 2014 Nov 17. PMID: 25402007.
 
+- [eggNOG-mapper](https://github.com/eggnogdb/eggnog-mapper)
+
+> Cantalapiedra CP, Hernández-Plaza A, Letunic I, Bork P, Huerta-Cepas J. eggNOG-mapper v2: Functional Annotation, Orthology Assignments, and Domain Prediction at the Metagenomic Scale. Mol Biol Evol. 2021 Dec 9;38(12):5825-5829. doi: 10.1093/molbev/msab293. PubMed PMID: 34597405.
+
 - [FastQC](https://www.bioinformatics.babraham.ac.uk/projects/fastqc/)
 
 > Andrews, S. (2010). FastQC: A Quality Control Tool for High Throughput Sequence Data [Online].
@@ -33,6 +37,10 @@
 - [mi-faser](https://academic.oup.com/nar/advance-article/doi/10.1093/nar/gkx1209/4670955)
 
 > Zhu C, Miller M, Marpaka S, Vaysberg P, Rühlemann M, Wu G, Heinsen FA, Tempel M, Zhao L, Leib W, Franke A, Bromberg Y. Functional sequencing read annotation for high precision microbiome analysis. Nucleic Acids Research. Volume 46, Issue 4. 2017. doi: 10.1093/nar/gkx1209.
+
+> Mahlich Y, Zhu C, Chung H, Velaga PK, De Paolis Kaluza MC, Radivojac P, Friedberg I, Bromberg Y. Learning from the unknown: exploring the range of bacterial functionality. Nucleic Acids Res. 2023 Oct 27;51(19):10162-10175. doi: 10.1093/nar/gkad757. PubMed PMID: 37739408.
+
+> Zhu C, Delmont TO, Vogel TM, Bromberg Y. Functional Basis of Microorganism Classification. PLoS Comput Biol. 2015 Aug 28;11(8):e1004472. doi: 10.1371/journal.pcbi.1004472. PubMed PMID: 26317871.
 
 - [MetaPhlAn3](http://segatalab.cibio.unitn.it/tools/metaphlan/index.html)
 


### PR DESCRIPTION
## Summary

- Replaces #64 and targets `feat/cite`, as requested by the maintainer.
- Adds the three runtime-attribution publications that are still absent from that branch: eggNOG-mapper v2 and two additional mi-faser-related papers.
- Keeps the delta documentation-only: one file and eight added lines, with no runtime, module, generated-file, or dependency changes.

GitHub would not allow the closed #64 to be reopened after its head branch was rebuilt, so this replacement keeps the same narrow contribution on the requested base.

Closes #61.

## Automated contribution disclosure

This PR was prepared and updated through an automated, AI-assisted workflow. The validation below was machine-executed; no claim of independent human review is made.

## Validation

- Compared `CITATIONS.md` on `feat/cite` with `toolCitationText()` and confirmed that the three added DOIs are the remaining missing runtime references.
- Crossref resolved all three DOIs and returned matching titles, authors, journals, volumes, issues, and pages.
- PubMed returned the three matching records and PMIDs: 34597405, 37739408, and 26317871.
- `npx.cmd --offline --yes prettier@3.8.3 --check <added-lines-only.md>` — passed.
- `git diff --check` — passed.
- The eggNOG-mapper repository link resolves to the active public `eggnogdb/eggnog-mapper` repository.

## Scope note

The full `CITATIONS.md` on the unmodified `feat/cite` baseline already fails Prettier. This update deliberately avoids reformatting unrelated upstream content; the eight added lines pass the same Prettier version in isolation.

## PR checklist

- [x] This description explains the change and its reason.
- [x] The added Markdown and citation metadata passed targeted checks.
- [x] Runtime tests and test-data changes are not applicable to this documentation-only delta.
