### PR TITLE
Address review follow-ups from PR #52

### DIFF
--- a/conf/modules.config
+++ b/conf/modules.config
@@ -75,11 +75,7 @@ process {
     }
     withName: EGGNOGMAPPER {
         ext.args = "--itype metagenome --genepred search --sensmode fast --pident 90 --query_cover 80"
-        // .emapper.hits is the full DIAMOND hit table, every hit for every query, and on a real
-        // metagenome it dwarfs everything else the pipeline publishes: 5.6 GB per sample against
-        // 1.1 GB of annotations and 0.2 GB of seed orthologs. Nothing downstream reads it, and
-        // reannotating against a newer eggNOG release takes the seed orthologs
-        // (emapper.py -m no_search --annotate_hits_table), not the hits, so it is not published.
+        // .emapper.hits is unpublished: several GB/sample, and reannotation uses the seed orthologs
         publishDir = [
             path: { "${params.outdir}/eggnogmapper/" },
             mode: params.publish_dir_mode,

--- a/docs/output.md
+++ b/docs/output.md
@@ -60,10 +60,11 @@ Other than FastQC, MultiQC and pipeline information, all other steps (the profil
 
 ### DIAMOND blastx
 
-Enabled with `--run_diamond`. Performs fast translated alignment of metagenomic reads against a protein reference database. Each read is aligned in all six reading frames and only significant hits are reported.
+Enabled with `--run_diamond`. Performs fast translated alignment of (meta)genomic reads against a protein reference database. Each read is aligned in all six reading frames and only significant hits are reported.
 
-> [!WARNING]
-> DIAMOND support is currently in beta and should be treated as work in progress. The module is still being validated in the full pipeline, including database handling, output behavior, and downstream reporting. Use with caution and independently review results before production use or interpretation.
+:::warning
+DIAMOND support is currently in beta and should be treated as work in progress. The module is still being validated in the full pipeline, including database handling, output behavior, and downstream reporting. Use with caution and independently review results before production use or interpretation.
+:::
 
 - `diamond/<db_name>/`
   - `*.tsv`: Tabular alignment results (BLAST tabular format 6) with one row per query-subject hit.
@@ -73,8 +74,9 @@ Enabled with `--run_diamond`. Performs fast translated alignment of metagenomic 
 
 Enabled with `--run_eggnogmapper`. Assigns functional annotations to sequences by mapping them to orthologous groups in the EggNOG database.
 
-> [!WARNING]
-> EggNOG-mapper support is currently in beta and should be treated as work in progress. The module is still being validated in the full pipeline, including database handling, output behavior, and downstream reporting. Use with caution and independently review results before production use or interpretation.
+:::warning
+EggNOG-mapper support is currently in beta and should be treated as work in progress. The module is still being validated in the full pipeline, including database handling, output behavior, and downstream reporting. Use with caution and independently review results before production use or interpretation.
+:::
 
 - `eggnogmapper/<db_name>/`
   - `*.emapper.annotations`: TSV file with functional annotations per query sequence, including GO terms, KEGG pathways, COG categories, and more.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -56,8 +56,9 @@ The pipeline will only run the profilers you explicitly turn on, and for which a
 | `--run_eggnogmapper`   | EggNOG-mapper   | Work in progress / beta |
 | `--run_rgi`            | RGI BWT         | Available               |
 
-> [!IMPORTANT]
-> Each `--run_` flag requires a matching database entry in the `--databases` CSV. Database rows for tools that are not enabled will be ignored.
+:::info
+Each `--run_` flag requires a matching database entry in the `--databases` CSV. Database rows for tools that are not enabled will be ignored.
+:::
 
 ## Databases input
 
@@ -104,7 +105,7 @@ fmhfunprofiler,kegg_v1,,,short;long,/data/databases/fmhfunprofiler_kegg.sig.zip
 
 :::warning
 EggNOG-mapper support is currently in beta and should be treated as work in progress. Database handling, output behavior, and downstream reporting are still being validated in the full pipeline, so use with caution and independently review results before production use or interpretation.
-::
+:::
 
 ```csv
 tool,db_name,db_entity,db_params,db_type,db_path
@@ -175,8 +176,9 @@ Wildcard variant databases are not currently supported by the pipeline. Only the
 
 [DIAMOND](https://github.com/bbuchfink/diamond/wiki/) is a high-throughput sequence aligner for translated (nucleotide-vs-protein) alignment. Enable it with `--run_diamond`.
 
-> [!WARNING]
-> DIAMOND support is currently in beta and should be treated as work in progress. Database handling, output behavior, and downstream reporting are still being validated in the full pipeline, so use with caution and independently review results before production use or interpretation.
+:::warning
+DIAMOND support is currently in beta and should be treated as work in progress. Database handling, output behavior, and downstream reporting are still being validated in the full pipeline, so use with caution and independently review results before production use or interpretation.
+:::
 
 #### Database preparation
 

--- a/main.nf
+++ b/main.nf
@@ -73,9 +73,6 @@ workflow {
         params.show_hidden,
     )
 
-    def profileUsesContainers = (workflow.containerEngine != null && workflow.containerEngine != '')
-
-
     //
     // WORKFLOW: Run main workflow
     //

--- a/nextflow.config
+++ b/nextflow.config
@@ -12,10 +12,6 @@ params {
 
     // Input options
     input                      = null
-    // References
-    // genome                     = null
-    // igenomes_base              = 's3://ngi-igenomes/igenomes/'
-    // igenomes_ignore            = false
 
     // MultiQC options
     multiqc_config             = null
@@ -53,7 +49,6 @@ params {
 
     // FASTQ preprocessing
     skip_preprocessing_qc            = false
-    save_runmerged_reads      = false
 
     // RGI
     run_rgi                   = false

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -73,21 +73,6 @@
                 }
             }
         },
-        "preprocessing_run_merging_options": {
-            "title": "Preprocessing run merging options",
-            "type": "object",
-            "description": "Options for per-sample run-merging",
-            "default": "",
-            "properties": {
-                "save_runmerged_reads": {
-                    "type": "boolean",
-                    "fa_icon": "fas fa-save",
-                    "description": "Save reads from samples that went through the run-merging step",
-                    "help_text": "Save the run- and library-concatenated reads of a given sample in FASTQ format.\n\n> \u26a0\ufe0f Only samples that went through the run-merging step of the pipeline will be stored in the resulting directory. \n\nIf you wish to save the files that go to the classification/profiling steps for samples that _did not_ go through run merging, you must supply the appropriate upstream `--save_<preprocessing_step>` flag.\n\n"
-                }
-            },
-            "fa_icon": "fas fa-clipboard-check"
-        },
         "profiling_options": {
             "title": "Profiling options",
             "type": "object",
@@ -286,9 +271,6 @@
         },
         {
             "$ref": "#/$defs/preprocessing_qc_options"
-        },
-        {
-            "$ref": "#/$defs/preprocessing_run_merging_options"
         },
         {
             "$ref": "#/$defs/profiling_options"

--- a/subworkflows/local/profile/main.nf
+++ b/subworkflows/local/profile/main.nf
@@ -19,134 +19,6 @@ include { EGGNOGMAPPER } from '../../../modules/nf-core/eggnogmapper/main'
 include { SEQKIT_FQ2FA } from '../../../modules/nf-core/seqkit/fq2fa/main'
 include { GUNZIP } from '../../../modules/nf-core/gunzip/main'
 
-// Custom Functions
-
-/**
-* Combine profiles with their original database, then separate into two channels.
-*
-* The channel elements are assumed to be tuples one of [ meta, profile ], and the
-* database to be of [db_key, meta, database_file].
-*
-* @param ch_profile A channel containing a meta and the profiling report of a given profiler
-* @param ch_database A channel containing a key, the database meta, and the database file/folders itself
-* @return A multiMap'ed output channel with two sub channels, one with the profile and the other with the db
-*/
-def sanitizeId(str) {
-    return str
-        .toString()
-        // underscores to hyphens, spaces to hyphens, drop special chars, collapse hyphens
-        .replaceAll(/_/, '-')
-        .replaceAll(/\s+/, '-')
-        .replaceAll(/[^\w\-.]/, '')
-        .replaceAll(/-+/, '-')
-}
-def prepareInputs(pairedreads, databases, tool_name, singleFqTool = false) {
-    /*
-        COMBINE READS WITH DATABASES - GROUPED BY TOOL, VERSION, AND PARAMS
-
-        Input:
-        - pairedreads: channel of [meta, [reads]]
-        - databases: channel of [meta_db, file]
-        - tool_name: string - filter databases to only this tool (e.g., 'humann_v3', 'rgi')
-        - singleFqTool: boolean - if true, reads need concatenation for PE samples
-
-        Output:
-        - channel of [meta_sample, reads, meta_db_grouped, db_files_map]
-          where each sample has entries for the specified tool
-    */
-    // Step 1: Filter databases to only the requested tool, then group by db_name and db_params
-    def ch_dbs_grouped = databases
-        .flatMap { meta_db, file_list ->
-            // Flatten: emit one tuple per file object
-            file_list.collect { file_obj ->
-                // Merge the file object's db_entity into the metadata
-                def meta_with_entity = meta_db + [db_entity: file_obj.db_entity]
-                [meta_with_entity, file_obj]
-            }
-        }
-        .filter { meta_db, file ->
-            meta_db.tool == tool_name
-        }
-        .map { meta_db, file ->
-            // Create grouping key: [tool, db_name, db_params]
-            def group_key = [meta_db.tool, meta_db.db_name ?: '', meta_db.db_params ?: '']
-            [group_key, meta_db, file]
-        }
-        // Group all files for same tool+db_name+db_params
-        .groupTuple()
-        .map { group_key, meta_db_list, files ->
-            def tool = group_key[0]
-            def db_name = group_key[1]
-            def db_params = group_key[2]
-
-            // Convert files list to Map keyed by db_entity for deterministic snapshots
-            // Map structure: entity_name -> db_path (entity is already in the key)
-            def files_map = [:]
-            [meta_db_list, files]
-                .transpose()
-                .each { meta_db, file ->
-                    // Store only the path
-                    files_map[meta_db.db_entity] = file.db_path
-                }
-
-            // Create consolidated metadata with db_entities as a Set
-            def meta_db_grouped = [id: sanitizeId("${tool}--${db_name}--${db_params}"), tool: tool, db_name: db_name, db_params: db_params, db_entities: files_map.keySet() as Set, num_files: files_map.size()]
-
-            // Return files as map
-            [meta_db_grouped, files_map.toSorted()]
-        }
-    // Step 2: Combine reads with ALL grouped databases (cartesian product)
-    // Each sample will get one entry per unique db_name+db_params combination for this tool
-    def reads_with_dbs = pairedreads
-        .combine(ch_dbs_grouped)
-        .map { meta_sample, reads, meta_db, db_files_map ->
-            // Flatten reads to ensure consistent list format
-            def flat_reads = [reads].flatten()
-
-            // Return: [meta_sample, reads_list, meta_db, db_files_map]
-            [meta_sample, flat_reads, meta_db, db_files_map]
-        }
-
-    // Step 3: Validate and add metadata based on tool type
-    def result = reads_with_dbs
-        .map { meta, reads, db_meta, db_files ->
-            def expected = meta.single_end | singleFqTool ? 1 : 2
-            if (reads.size() != expected) {
-                error("PE-aware tool (${!singleFqTool})  '${db_meta.tool}': expected ${expected} read file(s) for sample ${meta.id} (single_end=${meta.single_end}), got ${reads.size()}")
-            }
-            [meta, reads, db_meta, db_files]
-        }
-        .multiMap { it ->
-            // Carry the database identity into the read meta so that ext.args, ext.prefix
-            // and publishDir can key on it, as nf-core/taxprofiler does. Only a subset is
-            // merged: meta_db also holds an id, which must not overwrite the sample id.
-            reads: [it[0] + it[2].subMap('tool', 'db_name', 'db_params'), it[1]]
-            db: [it[2], it[3]]
-        }
-    return result
-}
-
-def getDbPath(groupeddb, entity = 'main', asTuple = false) {
-    // Extract the relevant database file path by entity key from the files map
-    def dbpath = groupeddb.map { meta_db, files_map ->
-        // files_map is now a Map[entity -> db_path], so direct lookup
-        if (!files_map.containsKey(entity)) {
-            error("No entity '${entity}' file found in database ${meta_db.id}")
-        }
-
-        def db_path = files_map[entity]
-        // Direct access to path
-
-        if (asTuple) {
-            return [meta_db, db_path]
-        }
-        else {
-            return db_path
-        }
-    }
-    return dbpath
-}
-
 workflow PROFILE {
     take:
     reads // [ [ meta ], [ reads ] ]
@@ -298,4 +170,133 @@ workflow TEST_PREPAREINPUTS_WRAPPER {
     emit:
     reads = testresult.reads
     db = testresult.db
+}
+
+
+// Custom Functions
+
+/**
+* Combine profiles with their original database, then separate into two channels.
+*
+* The channel elements are assumed to be tuples one of [ meta, profile ], and the
+* database to be of [db_key, meta, database_file].
+*
+* @param ch_profile A channel containing a meta and the profiling report of a given profiler
+* @param ch_database A channel containing a key, the database meta, and the database file/folders itself
+* @return A multiMap'ed output channel with two sub channels, one with the profile and the other with the db
+*/
+def sanitizeId(str) {
+    return str
+        .toString()
+        // underscores to hyphens, spaces to hyphens, drop special chars, collapse hyphens
+        .replaceAll(/_/, '-')
+        .replaceAll(/\s+/, '-')
+        .replaceAll(/[^\w\-.]/, '')
+        .replaceAll(/-+/, '-')
+}
+def prepareInputs(pairedreads, databases, tool_name, singleFqTool = false) {
+    /*
+        COMBINE READS WITH DATABASES - GROUPED BY TOOL, VERSION, AND PARAMS
+
+        Input:
+        - pairedreads: channel of [meta, [reads]]
+        - databases: channel of [meta_db, file]
+        - tool_name: string - filter databases to only this tool (e.g., 'humann_v3', 'rgi')
+        - singleFqTool: boolean - if true, reads need concatenation for PE samples
+
+        Output:
+        - channel of [meta_sample, reads, meta_db_grouped, db_files_map]
+          where each sample has entries for the specified tool
+    */
+    // Step 1: Filter databases to only the requested tool, then group by db_name and db_params
+    def ch_dbs_grouped = databases
+        .flatMap { meta_db, file_list ->
+            // Flatten: emit one tuple per file object
+            file_list.collect { file_obj ->
+                // Merge the file object's db_entity into the metadata
+                def meta_with_entity = meta_db + [db_entity: file_obj.db_entity]
+                [meta_with_entity, file_obj]
+            }
+        }
+        .filter { meta_db, file ->
+            meta_db.tool == tool_name
+        }
+        .map { meta_db, file ->
+            // Create grouping key: [tool, db_name, db_params]
+            def group_key = [meta_db.tool, meta_db.db_name ?: '', meta_db.db_params ?: '']
+            [group_key, meta_db, file]
+        }
+        // Group all files for same tool+db_name+db_params
+        .groupTuple()
+        .map { group_key, meta_db_list, files ->
+            def tool = group_key[0]
+            def db_name = group_key[1]
+            def db_params = group_key[2]
+
+            // Convert files list to Map keyed by db_entity for deterministic snapshots
+            // Map structure: entity_name -> db_path (entity is already in the key)
+            def files_map = [:]
+            [meta_db_list, files]
+                .transpose()
+                .each { meta_db, file ->
+                    // Store only the path
+                    files_map[meta_db.db_entity] = file.db_path
+                }
+
+            // Create consolidated metadata with db_entities as a Set
+            def meta_db_grouped = [id: sanitizeId("${tool}--${db_name}--${db_params}"), tool: tool, db_name: db_name, db_params: db_params, db_entities: files_map.keySet() as Set, num_files: files_map.size()]
+
+            // Return files as map
+            [meta_db_grouped, files_map.toSorted()]
+        }
+    // Step 2: Combine reads with ALL grouped databases (cartesian product)
+    // Each sample will get one entry per unique db_name+db_params combination for this tool
+    def reads_with_dbs = pairedreads
+        .combine(ch_dbs_grouped)
+        .map { meta_sample, reads, meta_db, db_files_map ->
+            // Flatten reads to ensure consistent list format
+            def flat_reads = [reads].flatten()
+
+            // Return: [meta_sample, reads_list, meta_db, db_files_map]
+            [meta_sample, flat_reads, meta_db, db_files_map]
+        }
+
+    // Step 3: Validate and add metadata based on tool type
+    def result = reads_with_dbs
+        .map { meta, reads, db_meta, db_files ->
+            def expected = meta.single_end | singleFqTool ? 1 : 2
+            if (reads.size() != expected) {
+                error("PE-aware tool (${!singleFqTool})  '${db_meta.tool}': expected ${expected} read file(s) for sample ${meta.id} (single_end=${meta.single_end}), got ${reads.size()}")
+            }
+            [meta, reads, db_meta, db_files]
+        }
+        .multiMap { it ->
+            // Carry the database identity into the read meta so that ext.args, ext.prefix
+            // and publishDir can key on it, as nf-core/taxprofiler does. Only a subset is
+            // merged: meta_db also holds an id, which must not overwrite the sample id.
+            reads: [it[0] + it[2].subMap('tool', 'db_name', 'db_params'), it[1]]
+            db: [it[2], it[3]]
+        }
+    return result
+}
+
+def getDbPath(groupeddb, entity = 'main', asTuple = false) {
+    // Extract the relevant database file path by entity key from the files map
+    def dbpath = groupeddb.map { meta_db, files_map ->
+        // files_map is now a Map[entity -> db_path], so direct lookup
+        if (!files_map.containsKey(entity)) {
+            error("No entity '${entity}' file found in database ${meta_db.id}")
+        }
+
+        def db_path = files_map[entity]
+        // Direct access to path
+
+        if (asTuple) {
+            return [meta_db, db_path]
+        }
+        else {
+            return db_path
+        }
+    }
+    return dbpath
 }


### PR DESCRIPTION
Removes three things:

1. `profileUsesContainers` variable
2. commented-out igenomes params
3. `save_runmerged_reads` param, which was in the schema and advertised FASTQ output the pipeline never publishes (TO-DO for v1.1.0 or beyond)

Also moves helper functions to bottom, trims the eggNOG-mapper publishDir comment, and converts the remaining GitHub-style admonitions in usage.md and output.md to the nf-core website syntax, fixing an unclosed `::` block in the process (thanks @jonasscheid).
